### PR TITLE
changing how assertions access instance variables 

### DIFF
--- a/config-serializer/assert.ts
+++ b/config-serializer/assert.ts
@@ -1,68 +1,78 @@
-function assertUInt8(target: any, key: string) {
+export function assertUInt8(target: any, key: string) {
     return assertInteger(target, key, 0, 0xFF);
 }
 
-function assertInt8(target: any, key: string) {
+export function assertInt8(target: any, key: string) {
     return assertInteger(target, key, -0x80, 0x7F);
 }
 
-function assertUInt16(target: any, key: string) {
+export function assertUInt16(target: any, key: string) {
     return assertInteger(target, key, 0, 0xFFFF);
 }
 
-function assertInt16(target: any, key: string) {
+export function assertInt16(target: any, key: string) {
     return assertInteger(target, key, -0x8000, 0x7FFF);
 }
 
-function assertUInt32(target: any, key: string) {
+export function assertUInt32(target: any, key: string) {
     return assertInteger(target, key, 0, 0xFFFFFFFF);
 }
 
-function assertInt32(target: any, key: string) {
+export function assertInt32(target: any, key: string) {
     return assertInteger(target, key, -0x80000000, 0x7FFFFFFF);
 }
 
-function assertCompactLength(target: any, key: string) {
+export function assertCompactLength(target: any, key: string) {
     return assertUInt16(target, key);
 }
 
 function assertInteger(target: any, key: string, min: number, max: number) {
-    let val = this[key];
-    if (delete this[key]) {
-        Object.defineProperty(target, key, {
-            get: function () {
-                return val;
-            },
-            set: function (newVal) {
-                if (newVal < min || newVal > max) {
-                    throw `${target.constructor.name}.${key}: ` +
-                          `Integer ${newVal} is outside the valid [${min}, ${max}] interval`;
+    const priv = '_' + key;
+
+    function getter() {
+        return this[priv];
+    }
+
+    function setter(newVal: any) {
+        if (this[priv] !== newVal) {
+            if (newVal < min || newVal > max) {
+                throw `${target.constructor.name}.${key}: ` +
+                    `Integer ${newVal} is outside the valid [${min}, ${max}] interval`;
+            }
+            this[priv] = newVal;
+        }
+    }
+
+    Object.defineProperty(target, key, {
+        get: getter,
+        set: setter,
+        enumerable: true,
+        configurable: true
+    });
+}
+
+export function assertEnum<E>(enumerated: E) {
+    return function(target: any, key: string) {
+        const priv = '_' + key;
+
+        function getter() {
+            return this[priv];
+        }
+
+        function setter(newVal: any) {
+            if (this[priv] !== newVal) {
+                if (enumerated[newVal] === undefined) {
+                    throw `${target.constructor.name}.${key}: ${newVal} is not enum`;
                 }
-                val = newVal;
-            },
+                this[priv] = newVal;
+            }
+        }
+
+        Object.defineProperty(target, key, {
+            get: getter,
+            set: setter,
             enumerable: true,
             configurable: true
         });
-    }
-}
-
-function assertEnum<E>(enumerated: E) {
-    return function(target: any, key: string) {
-        let val = this[key];
-        if (delete this[key]) {
-            Object.defineProperty(target, key, {
-                get: function () {
-                    return val;
-                },
-                set: function (newVal) {
-                    if (enumerated[newVal] === undefined) {
-                        throw `${target.constructor.name}.${key}: ${newVal} is not enum`;
-                    }
-                    val = newVal;
-                },
-                enumerable: true,
-                configurable: true
-            });
-        }
     };
 }

--- a/config-serializer/config-items/DelayMacroAction.ts
+++ b/config-serializer/config-items/DelayMacroAction.ts
@@ -1,9 +1,10 @@
 import {UhkBuffer} from '../UhkBuffer';
 import {MacroAction, macroActionType, MacroActionId} from './MacroAction';
+import {assertUInt16} from '../assert';
 
 export class DelayMacroAction extends MacroAction {
 
-    // @assertUInt16
+    @assertUInt16
     delay: number;
 
     _fromJsObject(jsObject: any): DelayMacroAction {

--- a/config-serializer/config-items/DualRoleKeystrokeAction.ts
+++ b/config-serializer/config-items/DualRoleKeystrokeAction.ts
@@ -1,5 +1,6 @@
 import {UhkBuffer} from '../UhkBuffer';
 import {keyActionType, KeyActionId, KeyAction} from './KeyAction';
+import {assertUInt8, assertEnum} from '../assert';
 
 enum LongPressAction {
     leftCtrl,
@@ -17,10 +18,10 @@ enum LongPressAction {
 
 export class DualRoleKeystrokeAction extends KeyAction {
 
-    // @assertUInt8
+    @assertUInt8
     scancode: number;
 
-    // @assertEnum(LongPressAction)
+    @assertEnum(LongPressAction)
     private longPressAction: LongPressAction;
 
     _fromJsObject(jsObject: any): DualRoleKeystrokeAction {

--- a/config-serializer/config-items/HoldKeyMacroAction.ts
+++ b/config-serializer/config-items/HoldKeyMacroAction.ts
@@ -1,9 +1,10 @@
 import {UhkBuffer} from '../UhkBuffer';
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
+import {assertUInt8} from '../assert';
 
 export class HoldKeyMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     scancode: number;
 
     _fromJsObject(jsObject: any): HoldKeyMacroAction {

--- a/config-serializer/config-items/HoldModifiersMacroAction.ts
+++ b/config-serializer/config-items/HoldModifiersMacroAction.ts
@@ -1,9 +1,10 @@
 import {UhkBuffer} from '../UhkBuffer';
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
+import {assertUInt8} from '../assert';
 
 export class HoldModifiersMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     modifierMask: number;
 
     _fromJsObject(jsObject: any): HoldModifiersMacroAction {

--- a/config-serializer/config-items/HoldMouseButtonsMacroAction.ts
+++ b/config-serializer/config-items/HoldMouseButtonsMacroAction.ts
@@ -1,9 +1,10 @@
 import {UhkBuffer} from '../UhkBuffer';
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
+import {assertUInt8} from '../assert';
 
 export class HoldMouseButtonsMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     mouseButtonsMask: number;
 
     _fromJsObject(jsObject: any): HoldMouseButtonsMacroAction {

--- a/config-serializer/config-items/KeyMap.ts
+++ b/config-serializer/config-items/KeyMap.ts
@@ -1,10 +1,11 @@
 import {Serializable} from '../Serializable';
 import {UhkBuffer} from '../UhkBuffer';
 import {Layers} from './Layers';
+import {assertUInt8} from '../assert';
 
 export class KeyMap extends Serializable<KeyMap> {
 
-    // @assertUInt8
+    @assertUInt8
     id: number;
 
     name: string;

--- a/config-serializer/config-items/KeystrokeAction.ts
+++ b/config-serializer/config-items/KeystrokeAction.ts
@@ -1,9 +1,10 @@
 import {UhkBuffer} from '../UhkBuffer';
 import {keyActionType, KeyActionId, KeyAction} from './KeyAction';
+import {assertUInt8} from '../assert';
 
 export class KeystrokeAction extends KeyAction {
 
-    // @assertUInt8
+    @assertUInt8
     scancode: number;
 
     _fromJsObject(jsObject: any): KeystrokeAction {

--- a/config-serializer/config-items/KeystrokeModifiersAction.ts
+++ b/config-serializer/config-items/KeystrokeModifiersAction.ts
@@ -1,5 +1,6 @@
 import {UhkBuffer} from '../UhkBuffer';
 import {keyActionType, KeyActionId, KeyAction} from './KeyAction';
+import {assertUInt8} from '../assert';
 
 export enum KeyModifiers {
     leftCtrl   = 1 << 0,
@@ -14,7 +15,7 @@ export enum KeyModifiers {
 
 export class KeystrokeModifiersAction extends KeyAction {
 
-    // @assertUInt8
+    @assertUInt8
     modifierMask: number;
 
     _fromJsObject(jsObject: any): KeystrokeModifiersAction {

--- a/config-serializer/config-items/KeystrokeWithModifiersAction.ts
+++ b/config-serializer/config-items/KeystrokeWithModifiersAction.ts
@@ -1,13 +1,14 @@
 import {UhkBuffer} from '../UhkBuffer';
 import {keyActionType, KeyActionId, KeyAction} from './KeyAction';
 import {KeyModifiers} from './KeystrokeModifiersAction';
+import {assertUInt8} from '../assert';
 
 export class KeystrokeWithModifiersAction extends KeyAction {
 
-    // @assertUInt8
+    @assertUInt8
     modifierMask: number;
 
-    // @assertUInt8
+    @assertUInt8
     scancode: number;
 
     _fromJsObject(jsObject: any): KeystrokeWithModifiersAction {

--- a/config-serializer/config-items/Macro.ts
+++ b/config-serializer/config-items/Macro.ts
@@ -1,10 +1,11 @@
 import {Serializable} from '../Serializable';
 import {UhkBuffer} from '../UhkBuffer';
 import {MacroActions} from './MacroActions';
+import {assertUInt8} from '../assert';
 
 export class Macro extends Serializable<Macro> {
 
-    // @assertUInt8
+    @assertUInt8
     id: number;
 
     isLooped: boolean;

--- a/config-serializer/config-items/Module.ts
+++ b/config-serializer/config-items/Module.ts
@@ -1,6 +1,7 @@
 import {Serializable} from '../Serializable';
 import {KeyActions} from './KeyActions';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8, assertEnum} from '../assert';
 
 enum PointerRole {
     none,
@@ -10,12 +11,12 @@ enum PointerRole {
 
 export class Module extends Serializable<Module> {
 
-    // @assertUInt8
+    @assertUInt8
     id: number;
 
     keyActions: KeyActions;
 
-    // @assertEnum(PointerRole)
+    @assertEnum(PointerRole)
     private pointerRole: PointerRole;
 
     _fromJsObject(jsObject: any): Module {

--- a/config-serializer/config-items/ModuleConfiguration.ts
+++ b/config-serializer/config-items/ModuleConfiguration.ts
@@ -1,5 +1,6 @@
 import {Serializable} from '../Serializable';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class ModuleConfiguration extends Serializable<ModuleConfiguration> {
 
@@ -7,16 +8,16 @@ export class ModuleConfiguration extends Serializable<ModuleConfiguration> {
      * module id enumeration is a separate story
      */
 
-    // @assertUInt8
+    @assertUInt8
     id: number;
 
-    // @assertUInt8
+    @assertUInt8
     initialPointerSpeed: number;
 
-    // @assertUInt8
+    @assertUInt8
     pointerAcceleration: number;
 
-    // @assertUInt8
+    @assertUInt8
     maxPointerSpeed: number;
 
     _fromJsObject(jsObject: any): ModuleConfiguration {

--- a/config-serializer/config-items/MouseAction.ts
+++ b/config-serializer/config-items/MouseAction.ts
@@ -1,5 +1,6 @@
 import {keyActionType, KeyActionId, KeyAction} from './KeyAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertEnum} from '../assert';
 
 enum MouseActionParam {
     leftClick,
@@ -19,7 +20,7 @@ enum MouseActionParam {
 
 export class MouseAction extends KeyAction {
 
-    // @assertUInt8
+    @assertEnum(MouseActionParam)
     mouseAction: MouseActionParam;
 
     _fromJsObject(jsObject: any): MouseAction {

--- a/config-serializer/config-items/MoveMouseMacroAction.ts
+++ b/config-serializer/config-items/MoveMouseMacroAction.ts
@@ -1,12 +1,13 @@
 import {MacroAction, macroActionType, MacroActionId} from './MacroAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertInt16} from '../assert';
 
 export class MoveMouseMacroAction extends MacroAction {
 
-    // @assertInt16
+    @assertInt16
     x: number;
 
-    // @assertInt16
+    @assertInt16
     y: number;
 
     _fromJsObject(jsObject: any): MoveMouseMacroAction {

--- a/config-serializer/config-items/PlayMacroAction.ts
+++ b/config-serializer/config-items/PlayMacroAction.ts
@@ -1,9 +1,10 @@
 import {keyActionType, KeyActionId, KeyAction} from './KeyAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class PlayMacroAction extends KeyAction {
 
-    // @assertUInt8
+    @assertUInt8
     macroId: number;
 
     _fromJsObject(jsObject: any): PlayMacroAction {

--- a/config-serializer/config-items/PressKeyMacroAction.ts
+++ b/config-serializer/config-items/PressKeyMacroAction.ts
@@ -1,9 +1,10 @@
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class PressKeyMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     scancode: number;
 
     _fromJsObject(jsObject: any): PressKeyMacroAction {

--- a/config-serializer/config-items/PressModifiersMacroAction.ts
+++ b/config-serializer/config-items/PressModifiersMacroAction.ts
@@ -1,9 +1,10 @@
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class PressModifiersMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     modifierMask: number;
 
     _fromJsObject(jsObject: any): PressModifiersMacroAction {

--- a/config-serializer/config-items/PressMouseButtonsMacroAction.ts
+++ b/config-serializer/config-items/PressMouseButtonsMacroAction.ts
@@ -1,9 +1,10 @@
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class PressMouseButtonsMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     mouseButtonsMask: number;
 
     _fromJsObject(jsObject: any): PressMouseButtonsMacroAction {

--- a/config-serializer/config-items/ReleaseKeyMacroAction.ts
+++ b/config-serializer/config-items/ReleaseKeyMacroAction.ts
@@ -1,9 +1,10 @@
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class ReleaseKeyMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     scancode: number;
 
     _fromJsObject(jsObject: any): ReleaseKeyMacroAction {

--- a/config-serializer/config-items/ReleaseModifiersMacroAction.ts
+++ b/config-serializer/config-items/ReleaseModifiersMacroAction.ts
@@ -1,9 +1,10 @@
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class ReleaseModifiersMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     modifierMask: number;
 
     _fromJsObject(jsObject: any): ReleaseModifiersMacroAction {

--- a/config-serializer/config-items/ReleaseMouseButtonsMacroAction.ts
+++ b/config-serializer/config-items/ReleaseMouseButtonsMacroAction.ts
@@ -1,9 +1,10 @@
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class ReleaseMouseButtonsMacroAction extends MacroAction {
 
-    // @assertUInt8
+    @assertUInt8
     mouseButtonsMask: number;
 
     _fromJsObject(jsObject: any): ReleaseMouseButtonsMacroAction {

--- a/config-serializer/config-items/ScrollMouseMacroAction.ts
+++ b/config-serializer/config-items/ScrollMouseMacroAction.ts
@@ -1,12 +1,13 @@
 import {MacroAction, MacroActionId, macroActionType} from './MacroAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertInt16} from '../assert';
 
 export class ScrollMouseMacroAction extends MacroAction {
 
-    // @assertInt16
+    @assertInt16
     x: number;
 
-    // @assertInt16
+    @assertInt16
     y: number;
 
     _fromJsObject(jsObject: any): ScrollMouseMacroAction {

--- a/config-serializer/config-items/SwitchKeymapAction.ts
+++ b/config-serializer/config-items/SwitchKeymapAction.ts
@@ -1,9 +1,10 @@
 import {keyActionType, KeyActionId, KeyAction} from './KeyAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8} from '../assert';
 
 export class SwitchKeymapAction extends KeyAction {
 
-    // @assertUInt8
+    @assertUInt8
     keymapId: number;
 
     _fromJsObject(jsObject: any): SwitchKeymapAction {

--- a/config-serializer/config-items/SwitchLayerAction.ts
+++ b/config-serializer/config-items/SwitchLayerAction.ts
@@ -1,5 +1,6 @@
 import {keyActionType, KeyActionId, KeyAction} from './KeyAction';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertEnum} from '../assert';
 
 export enum LayerName {
     mod,
@@ -11,7 +12,7 @@ export class SwitchLayerAction extends KeyAction {
 
     isLayerToggleable: boolean;
 
-    // @assertEnum(LayerName)
+    @assertEnum(LayerName)
     private _layer: LayerName;
 
     _fromJsObject(jsObject: any): SwitchLayerAction {

--- a/config-serializer/config-items/UhkConfiguration.ts
+++ b/config-serializer/config-items/UhkConfiguration.ts
@@ -3,21 +3,22 @@ import {ModuleConfigurations} from './ModuleConfigurations';
 import {KeyMaps} from './KeyMaps';
 import {Macros} from './Macros';
 import {UhkBuffer} from '../UhkBuffer';
+import {assertUInt8, assertUInt32} from '../assert';
 
 export class UhkConfiguration extends Serializable<UhkConfiguration> {
 
     signature: string;
 
-    // @assertUInt8
+    @assertUInt8
     dataModelVersion: number;
 
-    // @assertUInt32
+    @assertUInt32
     prologue: number;
 
-    // @assertUInt8
+    @assertUInt8
     hardwareId: number;
 
-    // @assertUInt8
+    @assertUInt8
     brandId: number;
 
     moduleConfigurations: ModuleConfigurations;
@@ -26,7 +27,7 @@ export class UhkConfiguration extends Serializable<UhkConfiguration> {
 
     macros: Macros;
 
-    // @assertUInt32
+    @assertUInt32
     epilogue: number;
 
     _fromJsObject(jsObject: any): UhkConfiguration {


### PR DESCRIPTION
to make them non-static-like. Based on http://stackoverflow.com/questions/35493375/typescript-class-with-property-decorator-acts-as-if-static

Let me know if there is a better way to import the assertions
fix for #36 