### PR TITLE
Data layer - Macro & UX improvments

### DIFF
--- a/src/components/macro/header/macro-header.component.ts
+++ b/src/components/macro/header/macro-header.component.ts
@@ -1,6 +1,11 @@
 import { Component, Input } from '@angular/core';
 
+import { Store } from '@ngrx/store';
+
 import { Macro } from '../../../config-serializer/config-items/Macro';
+
+import { MacroActions } from '../../../store/actions';
+import { AppState } from '../../../store/index';
 
 @Component({
     selector: 'macro-header',
@@ -10,18 +15,17 @@ import { Macro } from '../../../config-serializer/config-items/Macro';
 export class MacroHeaderComponent {
     @Input() macro: Macro;
 
-    constructor() { }
+    constructor(private store: Store<AppState>) { }
 
     removeMacro() {
-        // TODO implement
+        this.store.dispatch(MacroActions.removeMacro(this.macro.id));
     }
 
     duplicateMacro() {
-        // TODO implement
+        this.store.dispatch(MacroActions.duplicateMacro(this.macro));
     }
 
-    /* tslint:disable:no-unused-variable */
     editMacroName(name: string) {
-        // TODO implement
+        this.store.dispatch(MacroActions.editMacroName(this.macro.id, name));
     }
 }

--- a/src/components/macro/item/macro-item.component.html
+++ b/src/components/macro/item/macro-item.component.html
@@ -1,11 +1,11 @@
 <div class="list-group-item action--item" [class.is-editing]="editing">
     <span *ngIf="moveable" class="glyphicon glyphicon-option-vertical action--movable" aria-hidden="true"></span>
-    <div class="action--item--wrap" [class.cursor]="!editing" (click)="editAction()">
+    <div class="action--item--wrap" [class.pointer]="!editing && editable" (click)="editAction()">
         <icon [name]="iconName"></icon>
         <div class="action--title">{{ title }}</div>
         <icon *ngIf="editable && macroAction && !editing" name="pencil"></icon>
     </div>
-    <icon *ngIf="deletable" name="trash" (click)="deleteAction(macroAction)"></icon>
+    <icon *ngIf="deletable" name="trash" (click)="deleteAction()"></icon>
 </div>
 <div class="list-group-item macro-action-editor__container" *ngIf="editable && editing">
   <macro-action-editor 

--- a/src/components/macro/item/macro-item.component.html
+++ b/src/components/macro/item/macro-item.component.html
@@ -3,7 +3,7 @@
   <icon [name]="iconName"></icon>
   <div class="action--title" [class.cursor]="!editing" (click)="editAction()">{{ title }}</div>
   <icon *ngIf="editable && macroAction && !editing" name="pencil" (click)="editAction()"></icon>
-  <icon *ngIf="deletable" name="trash" (click)="deleteAction()"></icon>
+  <icon *ngIf="deletable" name="trash" (click)="deleteAction(macroAction)"></icon>
 </div>
 <div class="list-group-item macro-action-editor__container" *ngIf="editable && editing">
   <macro-action-editor 

--- a/src/components/macro/item/macro-item.component.html
+++ b/src/components/macro/item/macro-item.component.html
@@ -1,9 +1,9 @@
 <div class="list-group-item action--item" [class.is-editing]="editing">
   <span *ngIf="moveable" class="glyphicon glyphicon-option-vertical action--movable" aria-hidden="true"></span>
   <icon [name]="iconName"></icon>
-  <div class="action--title" (click)="editAction()">{{ title }}</div>
+  <div class="action--title" [class.cursor]="!editing" (click)="editAction()">{{ title }}</div>
+  <icon *ngIf="editable && macroAction && !editing" name="pencil" (click)="editAction()"></icon>
   <icon *ngIf="deletable" name="trash" (click)="deleteAction()"></icon>
-  <icon *ngIf="editable" name="pencil" (click)="editAction()"></icon>
 </div>
 <div class="list-group-item macro-action-editor__container" *ngIf="editable && editing">
   <macro-action-editor 

--- a/src/components/macro/item/macro-item.component.html
+++ b/src/components/macro/item/macro-item.component.html
@@ -1,9 +1,11 @@
 <div class="list-group-item action--item" [class.is-editing]="editing">
-  <span *ngIf="moveable" class="glyphicon glyphicon-option-vertical action--movable" aria-hidden="true"></span>
-  <icon [name]="iconName"></icon>
-  <div class="action--title" [class.cursor]="!editing" (click)="editAction()">{{ title }}</div>
-  <icon *ngIf="editable && macroAction && !editing" name="pencil" (click)="editAction()"></icon>
-  <icon *ngIf="deletable" name="trash" (click)="deleteAction(macroAction)"></icon>
+    <span *ngIf="moveable" class="glyphicon glyphicon-option-vertical action--movable" aria-hidden="true"></span>
+    <div class="action--item--wrap" [class.cursor]="!editing" (click)="editAction()">
+        <icon [name]="iconName"></icon>
+        <div class="action--title">{{ title }}</div>
+        <icon *ngIf="editable && macroAction && !editing" name="pencil"></icon>
+    </div>
+    <icon *ngIf="deletable" name="trash" (click)="deleteAction(macroAction)"></icon>
 </div>
 <div class="list-group-item macro-action-editor__container" *ngIf="editable && editing">
   <macro-action-editor 

--- a/src/components/macro/item/macro-item.component.scss
+++ b/src/components/macro/item/macro-item.component.scss
@@ -1,3 +1,5 @@
+@import '../../../main-app/global-styles';
+
 :host {
     &.macro-item:first-of-type {
         .list-group-item {
@@ -43,6 +45,22 @@
         &.is-editing {
             background: #f5f5f5;
         }
+
+        &--wrap {
+            justify-content: space-between;
+
+            &.cursor {
+                &:hover {
+                    cursor: pointer;
+                    color: $icon-hover;
+                }
+            }
+        }
+    }
+
+    &--title {
+        display: flex;
+        flex: 1;
     }
 
     &--movable {
@@ -58,8 +76,4 @@
     border-radius: 0;
     border-left: 0;
     border-right: 0;
-}
-
-.cursor {
-    cursor: pointer;
 }

--- a/src/components/macro/item/macro-item.component.scss
+++ b/src/components/macro/item/macro-item.component.scss
@@ -49,7 +49,7 @@
         &--wrap {
             justify-content: space-between;
 
-            &.cursor {
+            &.pointer {
                 &:hover {
                     cursor: pointer;
                     color: $icon-hover;

--- a/src/components/macro/item/macro-item.component.scss
+++ b/src/components/macro/item/macro-item.component.scss
@@ -18,44 +18,48 @@
             background: #f5f5f5;
         }
     }
+}
 
-    .action {
-        &--item {
+.action {
+    &--item {
+        display: flex;
+        flex-shrink: 0;
+        border: 0;
+        border-bottom: 1px solid #ddd;
+
+        icon {
+            margin: 0 5px;
+        }
+
+        > div {
             display: flex;
-            flex-shrink: 0;
-            border: 0;
-            border-bottom: 1px solid #ddd;
-
-            icon {
-                margin: 0 5px;
-            }
-
-            > div {
-                display: flex;
-                flex: 1;
-            }
-
-            &:first-child {
-                border-radius: 0;
-            }
-
-            &.is-editing {
-                background: #f5f5f5;
-            }
+            flex: 1;
         }
 
-        &--movable {
-            &:hover {
-                cursor: move;
-            }
+        &:first-child {
+            border-radius: 0;
+        }
+
+        &.is-editing {
+            background: #f5f5f5;
         }
     }
 
-    .macro-action-editor__container {
-        padding-top: 0;
-        padding-bottom: 0;
-        border-radius: 0;
-        border-left: 0;
-        border-right: 0;
+    &--movable {
+        &:hover {
+            cursor: move;
+        }
     }
+}
+
+.macro-action-editor__container {
+    padding-top: 0;
+    padding-bottom: 0;
+    border-radius: 0;
+    border-left: 0;
+    border-right: 0;
+}
+
+.cursor {
+    cursor: pointer;
 }

--- a/src/components/macro/item/macro-item.component.ts
+++ b/src/components/macro/item/macro-item.component.ts
@@ -29,7 +29,7 @@ export class MacroItemComponent implements OnInit, OnChanges {
     @Output() save = new EventEmitter<MacroAction>();
     @Output() cancel = new EventEmitter<void>();
     @Output() edit = new EventEmitter<void>();
-    @Output() delete = new EventEmitter<MacroAction>();
+    @Output() delete = new EventEmitter<void>();
 
     private title: string;
     private iconName: string;
@@ -72,8 +72,8 @@ export class MacroItemComponent implements OnInit, OnChanges {
         this.cancel.emit();
     }
 
-    deleteAction(macroAction: MacroAction): void {
-        this.delete.emit(macroAction);
+    deleteAction(): void {
+        this.delete.emit();
     }
 
     private updateView(): void {

--- a/src/components/macro/item/macro-item.component.ts
+++ b/src/components/macro/item/macro-item.component.ts
@@ -29,7 +29,7 @@ export class MacroItemComponent implements OnInit, OnChanges {
     @Output() save = new EventEmitter<MacroAction>();
     @Output() cancel = new EventEmitter<void>();
     @Output() edit = new EventEmitter<void>();
-    @Output() delete = new EventEmitter<void>();
+    @Output() delete = new EventEmitter<MacroAction>();
 
     private title: string;
     private iconName: string;
@@ -53,8 +53,6 @@ export class MacroItemComponent implements OnInit, OnChanges {
     }
 
     saveEditedAction(editedAction: MacroAction): void {
-        // @todo save this to keyboard
-        console.log('Saved action', editedAction);
         this.macroAction = editedAction;
         this.editing = false;
         this.updateView();
@@ -74,8 +72,8 @@ export class MacroItemComponent implements OnInit, OnChanges {
         this.cancel.emit();
     }
 
-    deleteAction(): void {
-        this.delete.emit();
+    deleteAction(macroAction: MacroAction): void {
+        this.delete.emit(macroAction);
     }
 
     private updateView(): void {

--- a/src/components/macro/item/macro-item.component.ts
+++ b/src/components/macro/item/macro-item.component.ts
@@ -62,7 +62,7 @@ export class MacroItemComponent implements OnInit, OnChanges {
     }
 
     editAction(): void {
-        if (!this.editable) {
+        if (!this.editable || this.editing) {
             return;
         }
         this.editing = true;

--- a/src/components/macro/macro.component.html
+++ b/src/components/macro/macro.component.html
@@ -1,9 +1,9 @@
-<template [ngIf]="macro$ | async">
-    <macro-header [macro]="macro$ | async"></macro-header>
+<template [ngIf]="macro">
+    <macro-header [macro]="macro"></macro-header>
     <div class="row list-container">
         <div class="col-xs-10 col-xs-offset-1 list-group">
-            <div class="macro-actions-container" [dragula]="'macroActions'" [dragulaModel]="(macro$ | async)?.macroActions.elements">
-                <macro-item *ngFor="let macroAction of (macro$ | async)?.macroActions.elements; let macroActionIndex = index"
+            <div class="macro-actions-container" [dragula]="'macroActions'" [dragulaModel]="(macro)?.macroActions">
+                <macro-item *ngFor="let macroAction of (macro)?.macroActions; let macroActionIndex = index"
                             [macroAction]="macroAction"
                             [editable]="true"
                             [deletable]="true"
@@ -11,7 +11,7 @@
                             (save)="saveAction($event, macroActionIndex)"
                             (edit)="editAction(macroActionIndex)"
                             (cancel)="cancelAction()"
-                            (delete)="deleteAction($event, macroActionIndex)"
+                            (delete)="deleteAction(macroAction, macroActionIndex)"
                             [attr.data-index]="macroActionIndex"
                 ></macro-item>
 
@@ -37,6 +37,6 @@
     </div>
 </template>
 
-<div *ngIf="!(macro$ | async)" class="not-found">
+<div *ngIf="!macro" class="not-found">
     Sorry, there is no macro with this id.
 </div>

--- a/src/components/macro/macro.component.html
+++ b/src/components/macro/macro.component.html
@@ -11,14 +11,17 @@
                             (save)="saveAction($event, macroActionIndex)"
                             (edit)="editAction(macroActionIndex)"
                             (cancel)="cancelAction()"
-                            (delete)="deleteAction($event, macroActionIndex)"></macro-item>
+                            (delete)="deleteAction($event, macroActionIndex)"
+                            [attr.data-index]="macroActionIndex"
+                ></macro-item>
 
                 <macro-item *ngIf="showNew" [macroAction]="newMacro"
                             [editable]="true"
                             [deletable]="false"
                             [moveable]="false"
                             (save)="addNewAction($event)"
-                            (cancel)="hideNewAction()"></macro-item>
+                            (cancel)="hideNewAction()"
+                ></macro-item>
             </div>
             <div class="list-group add-new__action-container" *ngIf="!showNew">
                 <div class="list-group-item action--item add-new__action-item no-reorder" (click)="showNewAction()">

--- a/src/components/macro/macro.component.html
+++ b/src/components/macro/macro.component.html
@@ -8,23 +8,21 @@
                             [editable]="true"
                             [deletable]="true"
                             [moveable]="true"
-                            (save)="onSaveAction($event, index)"
-                            (edit)="onEditAction(macroActionIndex)"
-                            (delete)="onDeleteAction(macroActionIndex)"></macro-item>
+                            (save)="saveAction($event, macroActionIndex)"
+                            (edit)="editAction(macroActionIndex)"
+                            (cancel)="cancelAction()"
+                            (delete)="deleteAction(macroActionIndex)"></macro-item>
+
+                <macro-item *ngIf="showNew" [macroAction]="newMacro"
+                            [editable]="true"
+                            [deletable]="false"
+                            [moveable]="false"
+                            (save)="addNewAction($event, macro$.id)"
+                            (cancel)="hideNewAction()"></macro-item>
             </div>
-            <div class="list-group add-new__action-container">
-                <div class="list-group-item action--item add-new__action-item no-reorder">
-                    <a class="add-new__action-item--link" (click)="addAction()"><i class="fa fa-plus"></i> Add new action item</a>
-                </div>
-                <div class="list-group-item new-macro-settings" *ngIf="hasChanges">
-                    <div class="helper"></div>
-                    <p>Remember to save your changes!</p>
-                    <div class="row">
-                        <div class="col-sm-12 flex-button-wrapper">
-                            <button class="btn btn-primary btn-sm pull-right flex-button settings-save" (click)="saveMacro()">Save macro</button>
-                            <button class="btn btn-default btn-sm pull-right flex-button settings-cancel" style="margin-right: .5em;" (click)="discardChanges()">Discard changes</button>
-                        </div>
-                    </div>
+            <div class="list-group add-new__action-container" *ngIf="!showNew">
+                <div class="list-group-item action--item add-new__action-item no-reorder" (click)="showNewAction()">
+                    <a class="add-new__action-item--link"><i class="fa fa-plus"></i> Add new macro action</a>
                 </div>
             </div>
         </div>

--- a/src/components/macro/macro.component.html
+++ b/src/components/macro/macro.component.html
@@ -24,8 +24,13 @@
                 ></macro-item>
             </div>
             <div class="list-group add-new__action-container" *ngIf="!showNew">
-                <div class="list-group-item action--item add-new__action-item no-reorder" (click)="showNewAction()">
-                    <a class="add-new__action-item--link"><i class="fa fa-plus"></i> Add new macro action</a>
+                <div class="list-group-item action--item add-new__action-item no-reorder clearfix">
+                    <a class="add-new__action-item--link" (click)="showNewAction()">
+                        <i class="fa fa-plus"></i> Add new macro action
+                    </a>
+                    <a class="add-new__action-item--link">
+                        <i class="fa fa fa-circle"></i> Add new capture keystroke
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/components/macro/macro.component.html
+++ b/src/components/macro/macro.component.html
@@ -1,30 +1,36 @@
-<macro-header [macro]="macro"></macro-header>
-<div class="row list-container">
-    <div class="col-xs-10 col-xs-offset-1 list-group">
-        <div class="macro-actions-container" [dragula]="'macroActions'" [dragulaModel]="macro.macroActions">
-            <macro-item *ngFor="let macroAction of macro.macroActions; let macroActionIndex = index"
-                        [macroAction]="macroAction"
-                        [editable]="true"
-                        [deletable]="true"
-                        [moveable]="true"
-                        (save)="onSaveAction($event, index)"
-                        (edit)="onEditAction(macroActionIndex)"
-                        (delete)="onDeleteAction(macroActionIndex)"></macro-item>
-        </div>
-        <div class="list-group add-new__action-container">
-            <div class="list-group-item action--item add-new__action-item no-reorder">
-                <a class="add-new__action-item--link" (click)="addAction()"><i class="fa fa-plus"></i> Add new action item</a>
+<template [ngIf]="macro$ | async">
+    <macro-header [macro]="macro$ | async"></macro-header>
+    <div class="row list-container">
+        <div class="col-xs-10 col-xs-offset-1 list-group">
+            <div class="macro-actions-container" [dragula]="'macroActions'" [dragulaModel]="(macro$ | async)?.macroActions.elements">
+                <macro-item *ngFor="let macroAction of (macro$ | async)?.macroActions.elements; let macroActionIndex = index"
+                            [macroAction]="macroAction"
+                            [editable]="true"
+                            [deletable]="true"
+                            [moveable]="true"
+                            (save)="onSaveAction($event, index)"
+                            (edit)="onEditAction(macroActionIndex)"
+                            (delete)="onDeleteAction(macroActionIndex)"></macro-item>
             </div>
-            <div class="list-group-item new-macro-settings" *ngIf="hasChanges">
-                <div class="helper"></div>
-                <p>Remember to save your changes!</p>
-                <div class="row">
-                    <div class="col-sm-12 flex-button-wrapper">
-                        <button class="btn btn-primary btn-sm pull-right flex-button settings-save" (click)="saveMacro()">Save macro</button>
-                        <button class="btn btn-default btn-sm pull-right flex-button settings-cancel" style="margin-right: .5em;" (click)="discardChanges()">Discard changes</button>
+            <div class="list-group add-new__action-container">
+                <div class="list-group-item action--item add-new__action-item no-reorder">
+                    <a class="add-new__action-item--link" (click)="addAction()"><i class="fa fa-plus"></i> Add new action item</a>
+                </div>
+                <div class="list-group-item new-macro-settings" *ngIf="hasChanges">
+                    <div class="helper"></div>
+                    <p>Remember to save your changes!</p>
+                    <div class="row">
+                        <div class="col-sm-12 flex-button-wrapper">
+                            <button class="btn btn-primary btn-sm pull-right flex-button settings-save" (click)="saveMacro()">Save macro</button>
+                            <button class="btn btn-default btn-sm pull-right flex-button settings-cancel" style="margin-right: .5em;" (click)="discardChanges()">Discard changes</button>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
+</template>
+
+<div *ngIf="!(macro$ | async)" class="not-found">
+    Sorry, there is no macro with this id.
 </div>

--- a/src/components/macro/macro.component.html
+++ b/src/components/macro/macro.component.html
@@ -11,13 +11,13 @@
                             (save)="saveAction($event, macroActionIndex)"
                             (edit)="editAction(macroActionIndex)"
                             (cancel)="cancelAction()"
-                            (delete)="deleteAction(macroActionIndex)"></macro-item>
+                            (delete)="deleteAction($event, macroActionIndex)"></macro-item>
 
                 <macro-item *ngIf="showNew" [macroAction]="newMacro"
                             [editable]="true"
                             [deletable]="false"
                             [moveable]="false"
-                            (save)="addNewAction($event, macro$.id)"
+                            (save)="addNewAction($event)"
                             (cancel)="hideNewAction()"></macro-item>
             </div>
             <div class="list-group add-new__action-container" *ngIf="!showNew">

--- a/src/components/macro/macro.component.scss
+++ b/src/components/macro/macro.component.scss
@@ -104,16 +104,31 @@ h1 {
 .add-new__action-item {
     border-radius: 0 0 4px 4px;
     border-top: 0;
+    padding: 0;
 
     &:hover {
         cursor: pointer;
     }
 
-    &--link,
-    &--link:active,
-    &--link:hover {
-        text-decoration: none;
+    &--link {
+        width: 50%;
+        float: left;
+        padding: 10px 5px;
+        text-align: center;
         color: $icon-hover;
+
+        &:first-of-type {
+            border-right: 1px solid #ddd;
+        }
+
+        &:hover {
+            text-decoration: none;
+            background: #e6e6e6;
+        }
+    }
+
+    .fa-circle {
+        color: #c00;
     }
 }
 

--- a/src/components/macro/macro.component.scss
+++ b/src/components/macro/macro.component.scss
@@ -152,3 +152,9 @@ h1 {
         user-select: none;
     }
 }
+
+.not-found {
+    margin-top: 30px;
+    font-size: 16px;
+    text-align: center;
+}

--- a/src/components/macro/macro.component.ts
+++ b/src/components/macro/macro.component.ts
@@ -2,7 +2,6 @@ import { Component, QueryList, ViewChildren } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { Store } from '@ngrx/store';
-import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/let';
 import 'rxjs/add/operator/publishReplay';
 import { Observable } from 'rxjs/Observable';
@@ -11,9 +10,10 @@ import { ConnectableObservable } from 'rxjs/observable/ConnectableObservable';
 import { DragulaService } from 'ng2-dragula/ng2-dragula';
 
 import { Macro } from '../../config-serializer/config-items/Macro';
+import { MacroAction } from '../../config-serializer/config-items/macro-action/MacroAction';
 import { MacroItemComponent } from './item/macro-item.component';
 
-import { AppState } from '../../store/index';
+import { AppState } from '../../store';
 import { getMacro } from '../../store/reducers/macro';
 
 @Component({
@@ -25,7 +25,9 @@ import { getMacro } from '../../store/reducers/macro';
 export class MacroComponent {
     @ViewChildren(MacroItemComponent) macroItems: QueryList<MacroItemComponent>;
     private macro$: Observable<Macro>;
-    private hasChanges: boolean = false;
+    private showNew: boolean = false;
+    private newMacro: Macro = undefined;
+    private activeEdit: number = undefined;
 
     constructor(
         private store: Store<AppState>,
@@ -43,45 +45,63 @@ export class MacroComponent {
             .params
             .select<number>('id')
             .switchMap((id: number) => store.let(getMacro(id)))
-            .do(() => {
-                this.hasChanges = false;
-            })
-            .publishReplay();
+            .publishReplay(1);
 
         this.macro$ = macroConnectable;
         macroConnectable.connect();
     }
 
-    /*addAction() {
-        this.hideOtherActionEditors(this.macro.macroActions.elements.length);
-        this.macro.macroActions.elements.push(undefined);
+    showNewAction() {
+        if (this.activeEdit) {
+            this.hideActiveEditor();
+        }
+
+        this.newMacro = undefined;
+        this.showNew = true;
     }
 
-    discardChanges() {
-        const id: number = this.macro.id;
-        this.macro = this.getMacro(id);
-        this.hasChanges = false;
+    hideNewAction() {
+        this.showNew = false;
     }
 
-    hideOtherActionEditors(index: number) {
+    addNewAction(macroAction: MacroAction, id: number) {
+        // TODO implement add
+    }
+
+    editAction(index: number) {
+        // Hide other editors when clicking edit button of a macro action
+        if (this.activeEdit) {
+            this.hideActiveEditor();
+        }
+
+        this.activeEdit = index;
+    }
+
+    cancelAction() {
+        this.activeEdit = undefined;
+    }
+
+    private hideActiveEditor() {
         this.macroItems.toArray().forEach((macroItem: MacroItemComponent, idx: number) => {
-            if (idx !== index) {
+            if (idx !== this.activeEdit) {
                 macroItem.cancelEdit();
             }
         });
     }
 
-    onEditAction(index: number) {
-        // Hide other editors when clicking edit button of a macro action
-        this.hideOtherActionEditors(index);
+    /*
+
+    discardChanges() {
+        const id: number = this.macro.id;
+        this.macro = this.getMacro(id);
     }
 
-    onSaveAction(macroAction: MacroAction, index: number) {
+    saveItem(macroAction: MacroAction, index: number) {
         this.hasChanges = true;
         this.macro.macroActions[index] = macroAction;
     }
 
-    onDeleteAction(index: number) {
+    deleteItem(index: number) {
         // @ todo show confirm action dialog
         this.macro.macroActions.splice(index, 1);
         this.hasChanges = true;

--- a/src/components/macro/macro.component.ts
+++ b/src/components/macro/macro.component.ts
@@ -2,8 +2,10 @@ import { Component, QueryList, ViewChildren } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { Store } from '@ngrx/store';
+import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/let';
 import 'rxjs/add/operator/publishReplay';
+import 'rxjs/add/operator/switchMap';
 import { Observable } from 'rxjs/Observable';
 import { ConnectableObservable } from 'rxjs/observable/ConnectableObservable';
 
@@ -61,9 +63,11 @@ export class MacroComponent {
         let macroConnectable: ConnectableObservable<Macro> = route
             .params
             .select<number>('id')
-            .switchMap((id: number) => {
-                this.currentId = +id;
-                return store.let(getMacro(id));
+            .switchMap((id: number) => store.let(getMacro(id)))
+            .do((macro: Macro) => {
+                if (macro) {
+                    this.currentId = macro.id;
+                }
             })
             .publishReplay(1);
 
@@ -115,7 +119,7 @@ export class MacroComponent {
 
     private hideActiveEditor() {
         this.macroItems.toArray().forEach((macroItem: MacroItemComponent, idx: number) => {
-            if (idx !== this.activeEdit) {
+            if (idx === this.activeEdit) {
                 macroItem.cancelEdit();
             }
         });

--- a/src/components/macro/macro.component.ts
+++ b/src/components/macro/macro.component.ts
@@ -30,6 +30,7 @@ export class MacroComponent {
     private newMacro: Macro = undefined;
     private activeEdit: number = undefined;
     private currentId: number;
+    private dragIndex: number;
 
     constructor(
         private store: Store<AppState>,
@@ -40,6 +41,20 @@ export class MacroComponent {
         dragulaService.setOptions('macroActions', {
             moves: function (el: any, container: any, handle: any) {
                 return handle.className.includes('action--movable');
+            }
+        });
+
+        dragulaService.drag.subscribe((value: any) => {
+            this.dragIndex = +value[1].getAttribute('data-index');
+        });
+
+        dragulaService.drop.subscribe((value: any) => {
+            if (value[4]) {
+                this.store.dispatch(MacroActions.reorderMacroAction(
+                    this.currentId,
+                    this.dragIndex,
+                    +value[4].getAttribute('data-index')
+                ));
             }
         });
 

--- a/src/components/popover/tab/macro/macro-tab.component.html
+++ b/src/components/popover/tab/macro/macro-tab.component.html
@@ -6,7 +6,7 @@
     <template [ngIf]="selectedMacroIndex >= 0">
       <div class="list-group"> 
         <macro-item *ngFor="let macroAction of macros[selectedMacroIndex].macroActions"
-                    [macroAction]="macroAction">
+                    [macroAction]="macroAction" [editable]="false">
         </macro-item>
       </div>
     </template>

--- a/src/store/actions/macro.ts
+++ b/src/store/actions/macro.ts
@@ -13,6 +13,7 @@ export namespace MacroActions {
     export const ADD_ACTION = MacroActions.PREFIX + 'Add macro action';
     export const SAVE_ACTION = MacroActions.PREFIX + 'Save macro action';
     export const DELETE_ACTION = MacroActions.PREFIX + 'Delete macro action';
+    export const REORDER_ACTION = MacroActions.PREFIX + 'Reorder macro action';
 
     export function removeMacro(id: number): Action {
         return {
@@ -66,6 +67,17 @@ export namespace MacroActions {
                 id: id,
                 index: index,
                 action: action
+            }
+        };
+    }
+
+    export function reorderMacroAction(id: number, oldIndex: number, newIndex: number): Action {
+        return {
+            type: MacroActions.REORDER_ACTION,
+            payload: {
+                id: id,
+                oldIndex: oldIndex,
+                newIndex: newIndex
             }
         };
     }

--- a/src/store/actions/macro.ts
+++ b/src/store/actions/macro.ts
@@ -1,6 +1,7 @@
 import { Action } from '@ngrx/store';
 
 import { Macro } from '../../config-serializer/config-items/Macro';
+import { MacroAction } from '../../config-serializer/config-items/macro-action/MacroAction';
 
 export namespace MacroActions {
     export const PREFIX = '[Macro] ';
@@ -9,8 +10,9 @@ export namespace MacroActions {
     export const EDIT_NAME = MacroActions.PREFIX + 'Edit macro title';
     export const REMOVE = MacroActions.PREFIX + 'Remove macro';
 
-    export const SAVE_ITEM = MacroActions.PREFIX + 'Save macro item';
-    export const DELETE_ITEM = MacroActions.PREFIX + 'Delete macro item';
+    export const ADD_ACTION = MacroActions.PREFIX + 'Add macro action';
+    export const SAVE_ACTION = MacroActions.PREFIX + 'Save macro action';
+    export const DELETE_ACTION = MacroActions.PREFIX + 'Delete macro action';
 
     export function removeMacro(id: number): Action {
         return {
@@ -36,16 +38,35 @@ export namespace MacroActions {
         };
     }
 
-    export function saveMacroItem(macro: Macro): Action {
+    export function addMacroAction(id: number, action: MacroAction): Action {
         return {
-            type: MacroActions.SAVE_ITEM,
-            payload: macro
+            type: MacroActions.ADD_ACTION,
+            payload: {
+                id: id,
+                action: action
+            }
         };
     }
-    export function deleteMacroItem(macro: Macro): Action {
+
+    export function saveMacroAction(id: number, index: number, action: MacroAction): Action {
         return {
-            type: MacroActions.DELETE_ITEM,
-            payload: macro
+            type: MacroActions.SAVE_ACTION,
+            payload: {
+                id: id,
+                index: index,
+                action: action
+            }
+        };
+    }
+
+    export function deleteMacroAction(id: number, index: number, action: MacroAction): Action {
+        return {
+            type: MacroActions.DELETE_ACTION,
+            payload: {
+                id: id,
+                index: index,
+                action: action
+            }
         };
     }
 }

--- a/src/store/actions/macro.ts
+++ b/src/store/actions/macro.ts
@@ -1,12 +1,51 @@
 import { Action } from '@ngrx/store';
 
+import { Macro } from '../../config-serializer/config-items/Macro';
+
 export namespace MacroActions {
     export const PREFIX = '[Macro] ';
-    export const GET_ALL = MacroActions.PREFIX + 'Get all macros';
 
-    export function getAll(): Action {
+    export const DUPLICATE = MacroActions.PREFIX + 'Duplicate macro';
+    export const EDIT_NAME = MacroActions.PREFIX + 'Edit macro title';
+    export const REMOVE = MacroActions.PREFIX + 'Remove macro';
+
+    export const SAVE_ITEM = MacroActions.PREFIX + 'Save macro item';
+    export const DELETE_ITEM = MacroActions.PREFIX + 'Delete macro item';
+
+    export function removeMacro(id: number): Action {
         return {
-            type: MacroActions.GET_ALL
+            type: MacroActions.REMOVE,
+            payload: id
+        };
+    }
+
+    export function duplicateMacro(macro: Macro): Action {
+        return {
+            type: MacroActions.DUPLICATE,
+            payload: macro
+        };
+    }
+
+    export function editMacroName(id: number, name: string): Action {
+        return {
+            type: MacroActions.EDIT_NAME,
+            payload: {
+                id: id,
+                name: name
+            }
+        };
+    }
+
+    export function saveMacroItem(macro: Macro): Action {
+        return {
+            type: MacroActions.SAVE_ITEM,
+            payload: macro
+        };
+    }
+    export function deleteMacroItem(macro: Macro): Action {
+        return {
+            type: MacroActions.DELETE_ITEM,
+            payload: macro
         };
     }
 }

--- a/src/store/actions/macro.ts
+++ b/src/store/actions/macro.ts
@@ -1,7 +1,7 @@
 import { Action } from '@ngrx/store';
 
 import { Macro } from '../../config-serializer/config-items/Macro';
-import { MacroAction } from '../../config-serializer/config-items/macro-action/MacroAction';
+import { MacroAction } from '../../config-serializer/config-items/macro-action';
 
 export namespace MacroActions {
     export const PREFIX = '[Macro] ';

--- a/src/store/effects/macro.ts
+++ b/src/store/effects/macro.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+
+import { Actions, Effect } from '@ngrx/effects';
+
+import 'rxjs/add/operator/map';
+
+import { MacroActions } from '../actions';
+
+@Injectable()
+export class MacroEffects {
+
+    @Effect()remove$: any = this.actions$
+        .ofType(MacroActions.REMOVE)
+        .map(() => {
+            // TODO: Waiting for the fix: https://github.com/angular/angular/issues/10770
+            // If state is empty router.navigate(['/macro']);
+            // Else router.navigate(['/macro']);
+        });
+
+    constructor(private actions$: Actions) {}
+}

--- a/src/store/reducers/macro.ts
+++ b/src/store/reducers/macro.ts
@@ -73,6 +73,29 @@ export default function(state = initialState, action: Action): Macro[] {
                 return macro;
             });
 
+        case MacroActions.REORDER_ACTION:
+            return state.map((macro: Macro) => {
+                if (macro.id === action.payload.id) {
+                    let newIndex: number = action.payload.newIndex;
+
+                    // We need to reduce the new index for one when we are moving action down
+                    if (newIndex > action.payload.oldIndex) {
+                        --newIndex;
+                    }
+
+                    newMacro = new Macro(macro);
+                    newMacro.macroActions.elements.splice(
+                        newIndex,
+                        0,
+                        newMacro.macroActions.elements.splice(action.payload.oldIndex, 1)[0]
+                    );
+
+                    return newMacro;
+                }
+
+                return macro;
+            });
+
         default: {
             return state;
         }

--- a/src/store/reducers/macro.ts
+++ b/src/store/reducers/macro.ts
@@ -41,7 +41,7 @@ export default function(state = initialState, action: Action): Macro[] {
             return state.map((macro: Macro) => {
                 if (macro.id === action.payload.id) {
                     newMacro = new Macro(macro);
-                    newMacro.macroActions.elements.push(action.payload.action);
+                    newMacro.macroActions.push(action.payload.action);
 
                     return newMacro;
                 }
@@ -53,7 +53,7 @@ export default function(state = initialState, action: Action): Macro[] {
             return state.map((macro: Macro) => {
                 if (macro.id === action.payload.id) {
                     newMacro = new Macro(macro);
-                    newMacro.macroActions.elements[action.payload.index] = action.payload.action;
+                    newMacro.macroActions[action.payload.index] = action.payload.action;
 
                     return newMacro;
                 }
@@ -65,7 +65,7 @@ export default function(state = initialState, action: Action): Macro[] {
             return state.map((macro: Macro) => {
                 if (macro.id === action.payload.id) {
                     newMacro = new Macro(macro);
-                    newMacro.macroActions.elements.splice(action.payload.index, 1);
+                    newMacro.macroActions.splice(action.payload.index, 1);
 
                     return newMacro;
                 }
@@ -84,10 +84,10 @@ export default function(state = initialState, action: Action): Macro[] {
                     }
 
                     newMacro = new Macro(macro);
-                    newMacro.macroActions.elements.splice(
+                    newMacro.macroActions.splice(
                         newIndex,
                         0,
-                        newMacro.macroActions.elements.splice(action.payload.oldIndex, 1)[0]
+                        newMacro.macroActions.splice(action.payload.oldIndex, 1)[0]
                     );
 
                     return newMacro;
@@ -103,9 +103,6 @@ export default function(state = initialState, action: Action): Macro[] {
 }
 
 export function getMacro(id: number) {
-    // Convert to real number
-    id = +id;
-
     if (isNaN(id)) {
         return (state$: Observable<AppState>) => state$
             .select(appState => appState.macros)

--- a/src/store/reducers/macro.ts
+++ b/src/store/reducers/macro.ts
@@ -12,10 +12,12 @@ import { AppState } from '../index';
 const initialState: Macro[] = [];
 
 export default function(state = initialState, action: Action): Macro[] {
+    let newMacro: Macro;
+
     switch (action.type) {
         case MacroActions.DUPLICATE:
 
-            let newMacro: Macro = new Macro(action.payload);
+            newMacro = new Macro(action.payload);
             newMacro.name = generateName(state, newMacro.name);
             newMacro.id = generateId(state);
 
@@ -34,6 +36,42 @@ export default function(state = initialState, action: Action): Macro[] {
 
         case MacroActions.REMOVE:
             return state.filter((macro: Macro) => macro.id !== action.payload);
+
+        case MacroActions.ADD_ACTION:
+            return state.map((macro: Macro) => {
+                if (macro.id === action.payload.id) {
+                    newMacro = new Macro(macro);
+                    newMacro.macroActions.elements.push(action.payload.action);
+
+                    return newMacro;
+                }
+
+                return macro;
+            });
+
+        case MacroActions.SAVE_ACTION:
+            return state.map((macro: Macro) => {
+                if (macro.id === action.payload.id) {
+                    newMacro = new Macro(macro);
+                    newMacro.macroActions.elements[action.payload.index] = action.payload.action;
+
+                    return newMacro;
+                }
+
+                return macro;
+            });
+
+        case MacroActions.DELETE_ACTION:
+            return state.map((macro: Macro) => {
+                if (macro.id === action.payload.id) {
+                    newMacro = new Macro(macro);
+                    newMacro.macroActions.elements.splice(action.payload.index, 1);
+
+                    return newMacro;
+                }
+
+                return macro;
+            });
 
         default: {
             return state;

--- a/src/store/reducers/macro.ts
+++ b/src/store/reducers/macro.ts
@@ -1,16 +1,88 @@
+import '@ngrx/core/add/operator/select';
 import { Action } from '@ngrx/store';
 
+import 'rxjs/add/operator/map';
+import { Observable } from 'rxjs/Observable';
+
 import { Macro } from '../../config-serializer/config-items/Macro';
+
 import { MacroActions } from '../actions';
+import { AppState } from '../index';
 
 const initialState: Macro[] = [];
 
 export default function(state = initialState, action: Action): Macro[] {
     switch (action.type) {
-        case MacroActions.GET_ALL:
-            break;
+        case MacroActions.DUPLICATE:
+
+            let newMacro: Macro = new Macro(action.payload);
+            newMacro.name = generateName(state, newMacro.name);
+            newMacro.id = generateId(state);
+
+            return [...state, newMacro];
+
+        case MacroActions.EDIT_NAME:
+            let name: string = generateName(state, action.payload.name);
+
+            return state.map((macro: Macro) => {
+                if (macro.id === action.payload.id) {
+                    macro.name = name;
+                }
+
+                return macro;
+            });
+
+        case MacroActions.REMOVE:
+            return state.filter((macro: Macro) => macro.id !== action.payload);
+
         default: {
             return state;
         }
     }
+}
+
+export function getMacro(id: number) {
+    // Convert to real number
+    id = +id;
+
+    if (isNaN(id)) {
+        return (state$: Observable<AppState>) => state$
+            .select(appState => appState.macros)
+            .map((macros: Macro[]) => {
+                if (macros.length > 0) {
+                    return macros[0];
+                } else {
+                    return undefined;
+                }
+            });
+    } else {
+        return (state$: Observable<AppState>) => state$
+            .select(appState => appState.macros)
+            .map((macros: Macro[]) => macros.find((macro: Macro) => macro.id === id));
+    }
+}
+
+function generateName(macros: Macro[], name: string) {
+    let suffix = 2;
+    const oldName: string = name;
+
+    while (macros.some((macro: Macro) => macro.name === name)) {
+        name = oldName + ` (${suffix})`;
+        ++suffix;
+    }
+
+    return name;
+}
+
+function generateId(macros: Macro[]) {
+    let newId = 0;
+
+    macros.forEach((macro: Macro) => {
+        if (macro.id > newId) {
+            newId = macro.id;
+        }
+    });
+
+    return ++newId;
+
 }


### PR DESCRIPTION
- [x] Edit macro name
- [x] Duplicate macro
- [x] Delete macro
- [x] Add macro action
- [x] Save macro action
- [x] Delete macro action
- [x] Reorder macro action

Because of the problems with data layer logic I needed to do some refactoring (because I was already refactoring I also added some UX improvements) :
- [x] Add new action is now separate element
- [x] Improved close other actions, now only currently opened item is closed
- [x] Icon pencil is hidden when you are editing action
- [x] Title is not clickable when you are editing action
- [x] Title have a cursor pointer now when not in editing mode
- [x] Add new item is hidden when you are adding new action
- [x] Switched positions of pencil and trash icons
- [x] Removed `Remember to save your changes!`
- [x] Move capture keystroke to the basic macro page
- [x] Add hover for whole line when not in edit mode