### PR TITLE
Fixed null problem

### DIFF
--- a/src/config-serializer/config-items/Module.ts
+++ b/src/config-serializer/config-items/Module.ts
@@ -50,7 +50,11 @@ export class Module extends Serializable<Module> {
         return {
             id: this.id,
             pointerRole: PointerRole[this.pointerRole],
-            keyActions: this.keyActions.map(keyAction => keyAction.toJsObject())
+            keyActions: this.keyActions.map(keyAction => {
+                if (keyAction) {
+                    return keyAction.toJsObject();
+                }
+            })
         };
     }
 

--- a/src/config-serializer/config-items/key-action/helper.ts
+++ b/src/config-serializer/config-items/key-action/helper.ts
@@ -66,6 +66,10 @@ export class Helper {
     }
 
     private static fromJSONObject(keyAction: any): KeyAction {
+        if (!keyAction) {
+            return;
+        }
+
         switch (keyAction.keyActionType) {
             case keyActionType.NoneAction:
                 return new NoneAction().fromJsObject(keyAction);


### PR DESCRIPTION
PR resolving #157.

Problem is that we are using array and not objects. And for example if you set action for key that is in the middle of the module you would have empty elements in the array before.

For example:

You set action for backspace key. This is the last element in layer one in module one. That means that you would create array with `keyActions[7]= keyAction`. When we are reading and saving this into JSON and array, you have 6 empty elements before. As you can see on the image in #157 JSON contains null for all empry elements before.

What I did is a **temporary solution**. Proper solution would be to remove array and use objects. This way you wouldn't have any problems with this. But this would require quite a lot of work.

**svg-keyboar-wrap.component.ts**

```js
changeKeyAction(keyAction: KeyAction): void {
        let keyId = this.keyEditConfig.keyId;
        this.keyEditConfig.keyActions[keyId] = keyAction;
    }
```
