### PR TITLE
style: Fix styelint 'selector-no-id' warning

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -66,6 +66,6 @@
     "selector-pseudo-element-colon-notation": "single",
     "selector-pseudo-element-no-unknown": true,
     "selector-type-case": "lower",
-    "selector-no-id": true
+    "selector-max-id": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^2.6.1",
     "sass-loader": "^6.0.3",
     "standard-version": "^4.0.0",
-    "stylelint": "^7.10.1",
+    "stylelint": "^7.12.0",
     "ts-loader": "^2.0.3",
     "tslint": "~5.4.3",
     "webpack": "^2.4.1",


### PR DESCRIPTION
Deprecation Warning: 'selector-no-id' has been deprecated and in 8.0 will be removed.
Instead use 'selector-max-id' with '0' as its primary option.
See: https://stylelint.io/user-guide/rules/selector-no-id/