### PR TITLE
fix(keymap): allow 0 in keymap abbr when rename

### DIFF
--- a/shared/src/store/reducers/user-configuration.ts
+++ b/shared/src/store/reducers/user-configuration.ts
@@ -274,7 +274,7 @@ export function getMacro(id: number) {
 }
 
 function generateAbbr(keymaps: Keymap[], abbr: string): string {
-    const chars: string[] = '123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+    const chars: string[] = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
     let position = 0;
 
     while (keymaps.some((keymap: Keymap) => keymap.abbreviation === abbr)) {


### PR DESCRIPTION
in #360 mentioned the generateAbbr method not contains 0 and 1 and it is a bug or not.
I think it is not bug because a function is calculate the next abbreviation and if we allow the 0 and 1 the the next calculated value will be xx0. So I added the 0, but I think I have to delete the 1 from the string and the new abbreviation will xx2 instead if xx0.
@mondalaci What is your opinion?