### PR TITLE
Fix key capture on Firefox

### DIFF
--- a/shared/src/components/svg/keys/svg-keyboard-key/svg-keyboard-key.component.ts
+++ b/shared/src/components/svg/keys/svg-keyboard-key/svg-keyboard-key.component.ts
@@ -118,7 +118,7 @@ export class SvgKeyboardKeyComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     @HostListener('keyup', ['$event'])
-    onKeyUpe(e: KeyboardEvent) {
+    onKeyUp(e: KeyboardEvent) {
         if (this.scanCodePressed) {
             e.preventDefault();
             this.scanCodePressed = false;

--- a/shared/src/components/svg/module/svg-module.component.html
+++ b/shared/src/components/svg/module/svg-module.component.html
@@ -7,6 +7,7 @@
             [width]="key.width" [height]="key.height"
             [attr.transform]="'translate(' + key.x + ' ' + key.y + ')'"
             [attr.fill]="key.fill"
+            [attr.tabindex]="0"
             [keyAction]="keyActions[i]"
             [active]="selected && i == selectedKey.keyId"
             [keybindAnimationEnabled]="keybindAnimationEnabled"


### PR DESCRIPTION
This fixes #367 by adding tabindex attribute to key svg element so Firefox can properly focus the key. Otherwise focus, focusout events do not get fired and using mouse middle click to change key quickly does not work in Firefox. 

Only Firefox v52+ support focusout event so this will still not work correctly on older FF versions than that.

Also fixes small typo in onKeyUp (was "onKeyUpe").