### PR TITLE
refactor(device): Rename UserConfigSize => MaxUserConfigSize

### DIFF
--- a/packages/uhk-agent/src/services/device.service.ts
+++ b/packages/uhk-agent/src/services/device.service.ts
@@ -47,7 +47,7 @@ export class DeviceService {
     public async loadConfigurations(event: Electron.Event): Promise<void> {
         try {
             const userConfiguration = await this.loadConfiguration(
-                SystemPropertyIds.UserConfigSize,
+                SystemPropertyIds.MaxUserConfigSize,
                 UsbCommand.ReadUserConfig,
                 'user configuration');
 

--- a/packages/uhk-usb/src/constants.ts
+++ b/packages/uhk-usb/src/constants.ts
@@ -31,5 +31,5 @@ export enum SystemPropertyIds {
     DataModelVersion = 2,
     FirmwareVersion = 3,
     HardwareConfigSize = 4,
-    UserConfigSize = 5
+    MaxUserConfigSize = 5
 }


### PR DESCRIPTION
Rename SystemPropertyIds.UserConfigSize => SystemPropertyIds.MaxUserConfigSize because it better describe which date will return from device