### PR TITLE
fix(app): Rename the title property of the uhk-message component

### DIFF
--- a/packages/uhk-web/src/app/components/missing-device/missing-device.component.html
+++ b/packages/uhk-web/src/app/components/missing-device/missing-device.component.html
@@ -1,1 +1,1 @@
-<uhk-message title="Cannot find your UHK" subtitle="Please plug it in!"></uhk-message>
+<uhk-message header="Cannot find your UHK" subtitle="Please plug it in!"></uhk-message>

--- a/packages/uhk-web/src/app/components/privilege-checker/privilege-checker.component.html
+++ b/packages/uhk-web/src/app/components/privilege-checker/privilege-checker.component.html
@@ -1,4 +1,4 @@
 <span class="privilege-checker-wrapper">
-    <uhk-message title="Cannot talk to your UHK" subtitle="Your UHK has been detected, but its permissions are not set up yet, so Agent can't talk to it."></uhk-message>
+    <uhk-message header="Cannot talk to your UHK" subtitle="Your UHK has been detected, but its permissions are not set up yet, so Agent can't talk to it."></uhk-message>
     <button class="btn btn-default btn-lg btn-primary" (click)="setUpPermissions()"> Set up permissions </button>
 </span>

--- a/packages/uhk-web/src/app/components/uhk-message/uhk-message.component.html
+++ b/packages/uhk-web/src/app/components/uhk-message/uhk-message.component.html
@@ -3,7 +3,7 @@
          [ngClass]="{'spin-logo': rotateLogo}"
          src="assets/images/agent-icon.png"/>
     <div class="messages">
-        <h1> {{ title }} </h1>
+        <h1> {{ header }} </h1>
         <h2> {{ subtitle }} </h2>
     </div>
 </span>

--- a/packages/uhk-web/src/app/components/uhk-message/uhk-message.component.ts
+++ b/packages/uhk-web/src/app/components/uhk-message/uhk-message.component.ts
@@ -7,7 +7,7 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UhkMessageComponent {
-    @Input() title: string;
+    @Input() header: string;
     @Input() subtitle: string;
     @Input() rotateLogo = false;
 }

--- a/packages/uhk-web/src/app/pages/loading-page/loading-device.page.ts
+++ b/packages/uhk-web/src/app/pages/loading-page/loading-device.page.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
     selector: 'loading-device',
     template: `
-        <uhk-message title="Loading keyboard configuration..."
+        <uhk-message header="Loading keyboard configuration..."
                      subtitle="Hang tight!"
                      [rotateLogo]="true"></uhk-message>
     `


### PR DESCRIPTION
Renaming eliminate the default behaviour of the title attribute of the
HTML elements.
close: #454 