### PR TITLE
ci: Add g++-multilib to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - libudev-dev
       - build-essential
       - libusb-1.0-0-dev
+      - g++-multilib
   chrome: stable
 
 install:


### PR DESCRIPTION
g++-multilib library need to build ia32 and ARM specific target in x64 architecture