### PR TITLE
Invert scroll on mac

### DIFF
--- a/packages/uhk-web/src/app/services/user-config.json
+++ b/packages/uhk-web/src/app/services/user-config.json
@@ -4917,7 +4917,7 @@
                 null,
                 {
                   "keyActionType": "mouse",
-                  "mouseAction": "scrollUp"
+                  "mouseAction": "scrollDown"
                 },
                 {
                   "keyActionType": "mouse",
@@ -4936,7 +4936,7 @@
                 null,
                 {
                   "keyActionType": "mouse",
-                  "mouseAction": "scrollDown"
+                  "mouseAction": "scrollUp"
                 },
                 null,
                 null,
@@ -5926,7 +5926,7 @@
                 null,
                 {
                   "keyActionType": "mouse",
-                  "mouseAction": "scrollUp"
+                  "mouseAction": "scrollDown"
                 },
                 {
                   "keyActionType": "mouse",
@@ -5945,7 +5945,7 @@
                 null,
                 {
                   "keyActionType": "mouse",
-                  "mouseAction": "scrollDown"
+                  "mouseAction": "scrollUp"
                 },
                 null,
                 null,
@@ -6927,7 +6927,7 @@
                 null,
                 {
                   "keyActionType": "mouse",
-                  "mouseAction": "scrollUp"
+                  "mouseAction": "scrollDown"
                 },
                 {
                   "keyActionType": "mouse",
@@ -6946,7 +6946,7 @@
                 null,
                 {
                   "keyActionType": "mouse",
-                  "mouseAction": "scrollDown"
+                  "mouseAction": "scrollUp"
                 },
                 null,
                 null,


### PR DESCRIPTION
Partially resolves https://github.com/UltimateHackingKeyboard/agent/issues/535

Flips mouse scroll up/down on 

- Colemak for Mac 
- Dvorak for Mac 
- QWERTY for Mac 


Logic to change this in the configurator is still needed. 