### PR TITLE
fix: use app.exit() instead of "quit" when "window-all-closed" electron event occurred

### DIFF
--- a/packages/uhk-agent/src/electron-main.ts
+++ b/packages/uhk-agent/src/electron-main.ts
@@ -133,13 +133,13 @@ app.on('ready', createWindow);
 
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
-    app.quit();
-});
-
-app.on('will-quit', () => {
     if (appUpdateService) {
         appUpdateService.saveFirtsRun();
     }
+    app.exit();
+});
+
+app.on('will-quit', () => {
 });
 
 app.on('activate', () => {


### PR DESCRIPTION
Maybe solve the auto-update failed on linux

related: #597 