### PR TITLE
fix: close device when any error occurred in the communication

### DIFF
--- a/packages/uhk-usb/src/uhk-hid-device.ts
+++ b/packages/uhk-usb/src/uhk-hid-device.ts
@@ -109,6 +109,7 @@ export class UhkHidDevice {
             device.read((err: any, receivedData: Array<number>) => {
                 if (err) {
                     this.logService.error('[UhkHidDevice] Transfer error: ', err);
+                    this.close();
                     return reject(err);
                 }
                 const logString = bufferToString(receivedData);


### PR DESCRIPTION
The close operation clear the device cache and force to create new USB device for the next operation 