### PR TITLE
Fix Sleep key for macOS users in Mac keymaps and Fn layers

### DIFF
--- a/packages/uhk-web/src/app/services/user-config.json
+++ b/packages/uhk-web/src/app/services/user-config.json
@@ -689,8 +689,9 @@
                 null,
                 {
                   "keyActionType": "keystroke",
-                  "type": "system",
-                  "scancode": 130
+                  "type": "media",
+                  "scancode": 184,
+                  "modifierMask": 12
                 },
                 null,
                 {
@@ -2653,8 +2654,9 @@
                 null,
                 {
                   "keyActionType": "keystroke",
-                  "type": "system",
-                  "scancode": 130
+                  "type": "media",
+                  "scancode": 184,
+                  "modifierMask": 12
                 },
                 null,
                 {
@@ -4611,8 +4613,9 @@
                 null,
                 {
                   "keyActionType": "keystroke",
-                  "type": "system",
-                  "scancode": 130
+                  "type": "media",
+                  "scancode": 184,
+                  "modifierMask": 12
                 },
                 null,
                 {


### PR DESCRIPTION
Not sure if this is only my system but the Sleep key on the Fn layer does not work on my Macbook. Changed it to be the shortcut on the official list of shortcut published by Apple: https://support.apple.com/en-us/HT201236 and it works as expected.

![image](https://user-images.githubusercontent.com/1243537/42073619-d51cb04a-7b35-11e8-8d4f-44b7ad26b057.png)
