### PR TITLE
refactor: use rxjs pipe syntax

### DIFF
--- a/packages/uhk-web/src/app/app.component.ts
+++ b/packages/uhk-web/src/app/app.component.ts
@@ -4,8 +4,6 @@ import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 import { Action, Store } from '@ngrx/store';
 
-import 'rxjs/add/operator/last';
-
 import { DoNotUpdateAppAction, UpdateAppAction } from './store/actions/app-update.action';
 import { EnableUsbStackTestAction } from './store/actions/device';
 import {

--- a/packages/uhk-web/src/app/components/add-on/add-on.component.ts
+++ b/packages/uhk-web/src/app/components/add-on/add-on.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/pluck';
+import { pluck } from 'rxjs/operators';
 
 @Component({
     selector: 'add-on',
@@ -18,6 +18,8 @@ export class AddOnComponent {
     constructor(route: ActivatedRoute) {
         this.name$ = route
             .params
-            .pluck<{}, string>('name');
+            .pipe(
+                pluck<{}, string>('name')
+            );
     }
 }

--- a/packages/uhk-web/src/app/components/keymap/add/keymap-add.component.ts
+++ b/packages/uhk-web/src/app/components/keymap/add/keymap-add.component.ts
@@ -4,8 +4,7 @@ import { Keymap } from 'uhk-common';
 
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/combineLatest';
-import 'rxjs/add/operator/publishReplay';
+import { combineLatest, publishReplay, refCount } from 'rxjs/operators';
 
 import { AppState } from '../../../store';
 import { KeymapActions } from '../../../store/actions';
@@ -29,11 +28,13 @@ export class KeymapAddComponent {
         this.filterExpression$ = new BehaviorSubject('');
 
         this.presets$ = this.presetsAll$
-            .combineLatest(this.filterExpression$, (keymaps: Keymap[], filterExpression: string) => {
-                return keymaps.filter((keymap: Keymap) => keymap.name.toLocaleLowerCase().includes(filterExpression));
-            })
-            .publishReplay(1)
-            .refCount();
+            .pipe(
+                combineLatest(this.filterExpression$, (keymaps: Keymap[], filterExpression: string) => {
+                    return keymaps.filter((keymap: Keymap) => keymap.name.toLocaleLowerCase().includes(filterExpression));
+                }),
+                publishReplay(1),
+                refCount()
+            );
     }
 
     filterKeyboards(filterExpression: string) {

--- a/packages/uhk-web/src/app/components/keymap/edit/keymap-edit-guard.service.ts
+++ b/packages/uhk-web/src/app/components/keymap/edit/keymap-edit-guard.service.ts
@@ -3,15 +3,14 @@ import { CanActivate, Router } from '@angular/router';
 import { Keymap } from 'uhk-common';
 
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { switchMap, tap } from 'rxjs/operators';
 
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/let';
-import 'rxjs/add/operator/switchMap';
 
 import { Store } from '@ngrx/store';
 
-import { AppState } from '../../../store/index';
+import { AppState } from '../../../store';
 import { getKeymaps } from '../../../store/reducers/user-configuration';
 
 @Injectable()
@@ -22,12 +21,14 @@ export class KeymapEditGuard implements CanActivate {
     canActivate(): Observable<boolean> {
         return this.store
             .let(getKeymaps())
-            .do((keymaps: Keymap[]) => {
-                const defaultKeymap = keymaps.find(keymap => keymap.isDefault);
-                if (defaultKeymap) {
-                    this.router.navigate(['/keymap', defaultKeymap.abbreviation]);
-                }
-            })
-            .switchMap(() => Observable.of(false));
+            .pipe(
+                tap((keymaps: Keymap[]) => {
+                    const defaultKeymap = keymaps.find(keymap => keymap.isDefault);
+                    if (defaultKeymap) {
+                        this.router.navigate(['/keymap', defaultKeymap.abbreviation]);
+                    }
+                }),
+                switchMap(() => of(false))
+            );
     }
 }

--- a/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.ts
+++ b/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.ts
@@ -5,7 +5,7 @@ import { Macro, MacroAction } from 'uhk-common';
 
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
-import 'rxjs/add/operator/pluck';
+import { pluck, switchMap } from 'rxjs/operators';
 
 import { MacroActions } from '../../../store/actions';
 import { AppState, macroPlaybackSupported } from '../../../store';
@@ -26,14 +26,17 @@ export class MacroEditComponent implements OnDestroy {
     macroPlaybackSupported$: Observable<boolean>;
 
     private subscription: Subscription;
+
     constructor(private store: Store<AppState>, public route: ActivatedRoute) {
         this.subscription = route
             .params
-            .pluck<{}, string>('id')
-            .switchMap((id: string) => {
-                this.macroId = +id;
-                return store.let(getMacro(this.macroId));
-            })
+            .pipe(
+                pluck<{}, string>('id'),
+                switchMap((id: string) => {
+                    this.macroId = +id;
+                    return store.let(getMacro(this.macroId));
+                })
+            )
             .subscribe((macro: Macro) => {
                 this.macro = macro;
             });

--- a/packages/uhk-web/src/app/components/macro/not-found/macro-not-found-guard.service.ts
+++ b/packages/uhk-web/src/app/components/macro/not-found/macro-not-found-guard.service.ts
@@ -3,9 +3,8 @@ import { CanActivate, Router } from '@angular/router';
 import { Macro } from 'uhk-common';
 
 import { Observable } from 'rxjs/Observable';
-
+import { map } from 'rxjs/operators';
 import 'rxjs/add/operator/let';
-import 'rxjs/add/operator/map';
 
 import { Store } from '@ngrx/store';
 
@@ -20,12 +19,14 @@ export class MacroNotFoundGuard implements CanActivate {
     canActivate(): Observable<boolean> {
         return this.store
             .let(getMacros())
-            .map((macros: Macro[]) => {
-                const hasMacros = macros.length > 0;
-                if (hasMacros) {
-                    this.router.navigate(['/macro', macros[0].id]);
-                }
-                return !hasMacros;
-            });
+            .pipe(
+                map((macros: Macro[]) => {
+                    const hasMacros = macros.length > 0;
+                    if (hasMacros) {
+                        this.router.navigate(['/macro', macros[0].id]);
+                    }
+                    return !hasMacros;
+                })
+            );
     }
 }

--- a/packages/uhk-web/src/app/components/popover/popover.component.ts
+++ b/packages/uhk-web/src/app/components/popover/popover.component.ts
@@ -16,8 +16,7 @@ import { animate, keyframes, state, style, transition, trigger } from '@angular/
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import 'rxjs/add/operator/combineLatest';
-import 'rxjs/add/operator/map';
+import { combineLatest, map } from 'rxjs/operators';
 
 import {
     KeyAction,
@@ -155,9 +154,10 @@ export class PopoverComponent implements OnChanges {
                 private cdRef: ChangeDetectorRef) {
         this.animationState = 'closed';
         this.keymaps$ = store.let(getKeymaps())
-            .combineLatest(this.currentKeymap$)
-            .map(([keymaps, currentKeymap]: [Keymap[], Keymap]) =>
-                keymaps.filter((keymap: Keymap) => currentKeymap.abbreviation !== keymap.abbreviation)
+            .pipe(
+                combineLatest(this.currentKeymap$),
+                map(([keymaps, currentKeymap]: [Keymap[], Keymap]) =>
+                        keymaps.filter((keymap: Keymap) => currentKeymap.abbreviation !== keymap.abbreviation))
             );
         this.macroPlaybackSupported$ = store.select(macroPlaybackSupported);
     }

--- a/packages/uhk-web/src/app/components/side-menu/side-menu.component.ts
+++ b/packages/uhk-web/src/app/components/side-menu/side-menu.component.ts
@@ -12,9 +12,6 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
 import { Store } from '@ngrx/store';
 
 import { Subscription } from 'rxjs/Subscription';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/let';
 
 import { AppState, getSideMenuPageState } from '../../store';
 import { MacroActions } from '../../store/actions';

--- a/packages/uhk-web/src/app/components/slider-wrapper/slider-wrapper.component.ts
+++ b/packages/uhk-web/src/app/components/slider-wrapper/slider-wrapper.component.ts
@@ -3,8 +3,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { NouisliderComponent } from 'ng2-nouislider';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/distinctUntilChanged';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 export interface SliderPips {
     mode: string;
@@ -80,9 +79,10 @@ export class SliderWrapperComponent implements AfterViewInit, ControlValueAccess
         if (!this.changeObserver$) {
             Observable.create(observer => {
                 this.changeObserver$ = observer;
-            }).debounceTime(this.changeDebounceTime)
-            .distinctUntilChanged()
-            .subscribe(this.propagateChange);
+            }).pipe(
+                debounceTime(this.changeDebounceTime),
+                distinctUntilChanged()
+            ).subscribe(this.propagateChange);
 
             return; // No change event on first change as the value is just being set
         }

--- a/packages/uhk-web/src/app/components/svg/wrap/svg-keyboard-wrap.component.ts
+++ b/packages/uhk-web/src/app/components/svg/wrap/svg-keyboard-wrap.component.ts
@@ -14,8 +14,8 @@ import {
 } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/map';
+import { of } from 'rxjs/observable/of';
+import { map } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 
 import {
@@ -319,40 +319,44 @@ export class SvgKeyboardWrapComponent implements OnInit, OnChanges {
             const playMacroAction: PlayMacroAction = keyAction;
             return this.store
                 .select(appState => appState.userConfiguration.macros)
-                .map(macroState => macroState.find(macro => {
-                    return macro.id === playMacroAction.macroId;
-                }).name)
-                .map(macroName => {
-                    const content: NameValuePair[] = [
-                        {
-                            name: 'Action type',
-                            value: 'Play macro'
-                        },
-                        {
-                            name: 'Macro name',
-                            value: macroName
-                        }
-                    ];
-                    return content;
-                });
+                .pipe(
+                    map(macroState => macroState.find(macro => {
+                        return macro.id === playMacroAction.macroId;
+                    }).name),
+                    map(macroName => {
+                        const content: NameValuePair[] = [
+                            {
+                                name: 'Action type',
+                                value: 'Play macro'
+                            },
+                            {
+                                name: 'Macro name',
+                                value: macroName
+                            }
+                        ];
+                        return content;
+                    })
+                );
         } else if (keyAction instanceof SwitchKeymapAction) {
             const switchKeymapAction: SwitchKeymapAction = keyAction;
             return this.store
                 .select(appState => appState.userConfiguration.keymaps)
-                .map(keymaps => keymaps.find(keymap => keymap.abbreviation === switchKeymapAction.keymapAbbreviation).name)
-                .map(keymapName => {
-                    const content: NameValuePair[] = [
-                        {
-                            name: 'Action type',
-                            value: 'Switch keymap'
-                        },
-                        {
-                            name: 'Keymap',
-                            value: keymapName
-                        }
-                    ];
-                    return content;
-                });
+                .pipe(
+                    map(keymaps => keymaps.find(keymap => keymap.abbreviation === switchKeymapAction.keymapAbbreviation).name),
+                    map(keymapName => {
+                        const content: NameValuePair[] = [
+                            {
+                                name: 'Action type',
+                                value: 'Switch keymap'
+                            },
+                            {
+                                name: 'Keymap',
+                                value: keymapName
+                            }
+                        ];
+                        return content;
+                    })
+                );
         } else if (keyAction instanceof SwitchLayerAction) {
             const switchLayerAction: SwitchLayerAction = keyAction;
             const content: NameValuePair[] =
@@ -370,9 +374,9 @@ export class SvgKeyboardWrapComponent implements OnInit, OnChanges {
                         value: switchLayerAction.switchLayerMode === SwitchLayerMode.toggle ? 'On' : 'Off'
                     }
                 ];
-            return Observable.of(content);
+            return of(content);
         }
 
-        return Observable.of([]);
+        return of([]);
     }
 }

--- a/packages/uhk-web/src/app/services/uhk-device-bootloader-not-active.guard.ts
+++ b/packages/uhk-web/src/app/services/uhk-device-bootloader-not-active.guard.ts
@@ -3,8 +3,7 @@ import { Store } from '@ngrx/store';
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
+import { tap } from 'rxjs/operators';
 
 import { AppState, bootloaderActive } from '../store';
 
@@ -15,10 +14,12 @@ export class UhkDeviceBootloaderNotActiveGuard implements CanActivate {
 
     canActivate(): Observable<boolean> {
         return this.store.select(bootloaderActive)
-            .do(active => {
-                if (!active) {
-                    this.router.navigate(['/']);
-                }
-            });
+            .pipe(
+                tap(active => {
+                    if (!active) {
+                        this.router.navigate(['/']);
+                    }
+                })
+            );
     }
 }

--- a/packages/uhk-web/src/app/services/uhk-device-connected.guard.ts
+++ b/packages/uhk-web/src/app/services/uhk-device-connected.guard.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/do';
+import { map, tap } from 'rxjs/operators';
 
 import { AppState, deviceConnected } from '../store/index';
 
@@ -14,11 +14,13 @@ export class UhkDeviceConnectedGuard implements CanActivate {
 
     canActivate(): Observable<boolean> {
         return this.store.select(deviceConnected)
-            .do(connected => {
-                if (connected) {
-                    this.router.navigate(['/']);
-                }
-            })
-            .map(connected => !connected);
+            .pipe(
+                tap(connected => {
+                    if (connected) {
+                        this.router.navigate(['/']);
+                    }
+                }),
+                map(connected => !connected)
+            );
     }
 }

--- a/packages/uhk-web/src/app/services/uhk-device-disconnected.guard.ts
+++ b/packages/uhk-web/src/app/services/uhk-device-disconnected.guard.ts
@@ -2,10 +2,9 @@ import { CanActivate, Router } from '@angular/router';
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
+import { tap } from 'rxjs/operators';
 
-import { AppState, deviceConnected } from '../store/index';
+import { AppState, deviceConnected } from '../store';
 import { Store } from '@ngrx/store';
 
 @Injectable()
@@ -15,10 +14,12 @@ export class UhkDeviceDisconnectedGuard implements CanActivate {
 
     canActivate(): Observable<boolean> {
         return this.store.select(deviceConnected)
-            .do(connected => {
-                if (!connected) {
-                    this.router.navigate(['/detection']);
-                }
-            });
+            .pipe(
+                tap(connected => {
+                    if (!connected) {
+                        this.router.navigate(['/detection']);
+                    }
+                })
+            );
     }
 }

--- a/packages/uhk-web/src/app/services/uhk-device-initialized.guard.ts
+++ b/packages/uhk-web/src/app/services/uhk-device-initialized.guard.ts
@@ -2,9 +2,7 @@ import { CanActivate, Router } from '@angular/router';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
-
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
+import { map, tap } from 'rxjs/operators';
 
 import { AppState, hasDevicePermission } from '../store/index';
 
@@ -15,11 +13,13 @@ export class UhkDeviceInitializedGuard implements CanActivate {
 
     canActivate(): Observable<boolean> {
         return this.store.select(hasDevicePermission)
-            .do(hasPermission => {
-                if (hasPermission) {
-                    this.router.navigate(['/detection']);
-                }
-            })
-            .map(hasPermission => !hasPermission);
+            .pipe(
+                tap(hasPermission => {
+                    if (hasPermission) {
+                        this.router.navigate(['/detection']);
+                    }
+                }),
+                map(hasPermission => !hasPermission)
+            );
     }
 }

--- a/packages/uhk-web/src/app/services/uhk-device-loaded.guard.ts
+++ b/packages/uhk-web/src/app/services/uhk-device-loaded.guard.ts
@@ -3,8 +3,7 @@ import { Store } from '@ngrx/store';
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
+import { map, tap } from 'rxjs/operators';
 
 import { AppState, deviceConfigurationLoaded } from '../store';
 
@@ -15,11 +14,13 @@ export class UhkDeviceLoadedGuard implements CanActivate {
 
     canActivate(): Observable<boolean> {
         return this.store.select(deviceConfigurationLoaded)
-            .do(loaded => {
-                if (loaded) {
-                    this.router.navigate(['/']);
-                }
-            })
-            .map(loaded => !loaded);
+            .pipe(
+                tap(loaded => {
+                    if (loaded) {
+                        this.router.navigate(['/']);
+                    }
+                }),
+                map(loaded => !loaded)
+            );
     }
 }

--- a/packages/uhk-web/src/app/services/uhk-device-loading.guard.ts
+++ b/packages/uhk-web/src/app/services/uhk-device-loading.guard.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/do';
+import { tap } from 'rxjs/operators';
 
 import { AppState, deviceConfigurationLoaded } from '../store';
 
@@ -14,10 +14,12 @@ export class UhkDeviceLoadingGuard implements CanActivate {
 
     canActivate(): Observable<boolean> {
         return this.store.select(deviceConfigurationLoaded)
-            .do(loaded => {
-                if (!loaded) {
-                    this.router.navigate(['/loading']);
-                }
-            });
+            .pipe(
+                tap(loaded => {
+                    if (!loaded) {
+                        this.router.navigate(['/loading']);
+                    }
+                })
+            );
     }
 }

--- a/packages/uhk-web/src/app/services/uhk-device-uninitialized.guard.ts
+++ b/packages/uhk-web/src/app/services/uhk-device-uninitialized.guard.ts
@@ -2,23 +2,24 @@ import { CanActivate, Router } from '@angular/router';
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
+import { tap } from 'rxjs/operators';
 
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
-
-import { AppState, hasDevicePermission } from '../store/index';
+import { AppState, hasDevicePermission } from '../store';
 
 @Injectable()
 export class UhkDeviceUninitializedGuard implements CanActivate {
 
-    constructor(private store: Store<AppState>, private router: Router) { }
+    constructor(private store: Store<AppState>, private router: Router) {
+    }
 
     canActivate(): Observable<boolean> {
         return this.store.select(hasDevicePermission)
-            .do(hasPermission => {
-                if (!hasPermission) {
-                    this.router.navigate(['/privilege']);
-                }
-            });
+            .pipe(
+                tap(hasPermission => {
+                    if (!hasPermission) {
+                        this.router.navigate(['/privilege']);
+                    }
+                })
+            );
     }
 }

--- a/packages/uhk-web/src/app/store/effects/app-update.ts
+++ b/packages/uhk-web/src/app/store/effects/app-update.ts
@@ -2,10 +2,7 @@ import { Injectable } from '@angular/core';
 import { Action } from '@ngrx/store';
 import { Actions, Effect } from '@ngrx/effects';
 import { Observable } from 'rxjs/Observable';
-
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/first';
+import { first, map, tap } from 'rxjs/operators';
 
 import { LogService, NotificationType } from 'uhk-common';
 
@@ -19,27 +16,33 @@ export class AppUpdateEffect {
     @Effect({ dispatch: false })
     appStart$: Observable<Action> = this.actions$
         .ofType(ActionTypes.UPDATE_APP)
-        .first()
-        .do(() => {
-            this.appUpdateRendererService.sendUpdateAndRestartApp();
-        });
+        .pipe(
+            first(),
+            tap(() => {
+                this.appUpdateRendererService.sendUpdateAndRestartApp();
+            })
+        );
 
     @Effect({ dispatch: false }) checkForUpdate$: Observable<Action> = this.actions$
         .ofType(AutoUpdateActionTypes.CHECK_FOR_UPDATE_NOW)
-        .do(() => {
-            this.logService.debug('[AppUpdateEffect] call checkForUpdate');
-            this.appUpdateRendererService.checkForUpdate();
-        });
+        .pipe(
+            tap(() => {
+                this.logService.debug('[AppUpdateEffect] call checkForUpdate');
+                this.appUpdateRendererService.checkForUpdate();
+            })
+        );
 
     @Effect() handleError$: Observable<Action> = this.actions$
         .ofType<UpdateErrorAction>(ActionTypes.UPDATE_ERROR)
-        .map(action => action.payload)
-        .map((message: string) => {
-            return new ShowNotificationAction({
-                type: NotificationType.Error,
-                message
-            });
-        });
+        .pipe(
+            map(action => action.payload),
+            map((message: string) => {
+                return new ShowNotificationAction({
+                    type: NotificationType.Error,
+                    message
+                });
+            })
+        );
 
     constructor(private actions$: Actions,
                 private appUpdateRendererService: AppUpdateRendererService,

--- a/packages/uhk-web/src/app/store/effects/keymap.ts
+++ b/packages/uhk-web/src/app/store/effects/keymap.ts
@@ -4,14 +4,8 @@ import { Router } from '@angular/router';
 import { Actions, Effect } from '@ngrx/effects';
 import { Action, Store } from '@ngrx/store';
 import { Observable } from 'rxjs/Observable';
-
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/pairwise';
-import 'rxjs/add/operator/startWith';
-import 'rxjs/add/operator/switchMap';
-import 'rxjs/add/operator/withLatestFrom';
-import 'rxjs/add/observable/of';
+import { of } from 'rxjs/observable/of';
+import { map, pairwise, startWith, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 
 import { Keymap } from 'uhk-common';
 import { findNewItem } from '../../util';
@@ -24,47 +18,60 @@ export class KeymapEffects {
 
     @Effect() loadKeymaps$: Observable<Action> = this.actions$
         .ofType(KeymapActions.LOAD_KEYMAPS)
-        .startWith(KeymapActions.loadKeymaps())
-        .switchMap(() => {
-            const presetsRequireContext = (<any>require).context('../../../res/presets', false, /.json$/);
-            const uhkPresets = presetsRequireContext.keys().map(presetsRequireContext) // load the presets into an array
-                .map((keymap: any) => new Keymap().fromJsonObject(keymap));
+        .pipe(
+            startWith(KeymapActions.loadKeymaps()),
+            switchMap(() => {
+                const presetsRequireContext = (<any>require).context('../../../res/presets', false, /.json$/);
+                const uhkPresets = presetsRequireContext.keys().map(presetsRequireContext) // load the presets into an array
+                    .map((keymap: any) => new Keymap().fromJsonObject(keymap));
 
-            return Observable.of(KeymapActions.loadKeymapsSuccess(uhkPresets));
-        });
+                return of(KeymapActions.loadKeymapsSuccess(uhkPresets));
+            })
+        );
 
     @Effect({ dispatch: false }) addOrDuplicate$: any = this.actions$
         .ofType(KeymapActions.ADD, KeymapActions.DUPLICATE)
-        .withLatestFrom(this.store.let(getKeymaps()).pairwise(), (action, latest) => latest)
-        .do(([prevKeymaps, newKeymaps]) => {
-            const newKeymap = findNewItem(prevKeymaps, newKeymaps);
-            this.router.navigate(['/keymap', newKeymap.abbreviation]);
-        });
+        .pipe(
+            withLatestFrom(this.store.let(getKeymaps())
+                .pipe(
+                    pairwise()
+                )
+            ),
+            map(([action, latest]) => latest),
+            tap(([prevKeymaps, newKeymaps]) => {
+                const newKeymap = findNewItem(prevKeymaps, newKeymaps);
+                this.router.navigate(['/keymap', newKeymap.abbreviation]);
+            })
+        );
 
     @Effect({ dispatch: false }) remove$: any = this.actions$
         .ofType(KeymapActions.REMOVE)
-        .withLatestFrom(this.store)
-        .map(latest => latest[1].userConfiguration.keymaps)
-        .do(keymaps => {
-            if (keymaps.length === 0) {
-                this.router.navigate(['/keymap/add']);
-            } else {
-                const favourite: Keymap = keymaps.find(keymap => keymap.isDefault);
-                this.router.navigate(['/keymap', favourite.abbreviation]);
-            }
-        });
+        .pipe(
+            withLatestFrom(this.store),
+            map(latest => latest[1].userConfiguration.keymaps),
+            tap(keymaps => {
+                if (keymaps.length === 0) {
+                    this.router.navigate(['/keymap/add']);
+                } else {
+                    const favourite: Keymap = keymaps.find(keymap => keymap.isDefault);
+                    this.router.navigate(['/keymap', favourite.abbreviation]);
+                }
+            })
+        );
 
     @Effect({ dispatch: false }) editAbbr$: any = this.actions$
         .ofType(KeymapActions.EDIT_ABBR)
-        .withLatestFrom(this.store)
-        .do(([action, store]: [KeymapActions.EditKeymapAbbreviationAction, AppState]) => {
-            for (const keymap of store.userConfiguration.keymaps) {
-                if (keymap.name === action.payload.name && keymap.abbreviation === action.payload.newAbbr) {
-                    this.router.navigate(['/keymap', action.payload.newAbbr]);
-                    return;
+        .pipe(
+            withLatestFrom(this.store),
+            tap(([action, store]: [KeymapActions.EditKeymapAbbreviationAction, AppState]) => {
+                for (const keymap of store.userConfiguration.keymaps) {
+                    if (keymap.name === action.payload.name && keymap.abbreviation === action.payload.newAbbr) {
+                        this.router.navigate(['/keymap', action.payload.newAbbr]);
+                        return;
+                    }
                 }
-            }
-        });
+            })
+        );
 
     constructor(private actions$: Actions, private router: Router, private store: Store<AppState>) { }
 }

--- a/packages/uhk-web/src/app/store/effects/macro.ts
+++ b/packages/uhk-web/src/app/store/effects/macro.ts
@@ -3,14 +3,10 @@ import { Router } from '@angular/router';
 
 import { Actions, Effect } from '@ngrx/effects';
 import { Store, Action } from '@ngrx/store';
-
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/pairwise';
-import 'rxjs/add/operator/withLatestFrom';
+import { map, pairwise, tap, withLatestFrom } from 'rxjs/operators';
 
 import { Macro } from 'uhk-common';
-import { KeymapActions, MacroActions } from '../actions';
+import { KeymapActions, MacroAction, MacroActions } from '../actions';
 import { AppState } from '../index';
 import { getMacros } from '../reducers/user-configuration';
 import { findNewItem } from '../../util';
@@ -19,29 +15,42 @@ import { findNewItem } from '../../util';
 export class MacroEffects {
 
     @Effect({ dispatch: false }) remove$: any = this.actions$
-        .ofType(MacroActions.REMOVE)
-        .do<any>(action => this.store.dispatch(KeymapActions.checkMacro(action.payload)))
-        .withLatestFrom(this.store)
-        .map(([action, state]) => state.userConfiguration.macros)
-        .do(macros => {
-            if (macros.length === 0) {
-                this.router.navigate(['/macro']);
-            } else {
-                this.router.navigate(['/macro', macros[0].id]);
-            }
-        });
+        .ofType<MacroAction>(MacroActions.REMOVE)
+        .pipe(
+            tap(action => this.store.dispatch(KeymapActions.checkMacro(action.payload))),
+            withLatestFrom(this.store),
+            map(([action, state]) => state.userConfiguration.macros),
+            tap(macros => {
+                    if (macros.length === 0) {
+                        return this.router.navigate(['/macro']);
+                    }
+
+                    return this.router.navigate(['/macro', macros[0].id]);
+                }
+            )
+        );
 
     @Effect({ dispatch: false }) addOrDuplicate$: any = this.actions$
-        .ofType(MacroActions.ADD, MacroActions.DUPLICATE)
-        .withLatestFrom(this.store.let(getMacros()).pairwise(), (action, latest) => ([action, latest[0], latest[1]]))
-        .do(([action, prevMacros, newMacros]: [Action, Macro[], Macro[]]) => {
-            const newMacro = findNewItem(prevMacros, newMacros);
-            const commands = ['/macro', newMacro.id];
-            if (action.type === MacroActions.ADD) {
-                commands.push('new');
-            }
-            this.router.navigate(commands);
-        });
+        .ofType<MacroAction>(MacroActions.ADD, MacroActions.DUPLICATE)
+        .pipe(
+            withLatestFrom(this.store.let(getMacros())
+                .pipe(
+                    pairwise()
+                )
+            ),
+            map(([action, latest]) => ([action, latest[0], latest[1]])),
+            tap(([action, prevMacros, newMacros]: [Action, Macro[], Macro[]]) => {
+                const newMacro = findNewItem(prevMacros, newMacros);
+                const commands = ['/macro', newMacro.id];
+                if (action.type === MacroActions.ADD) {
+                    commands.push('new');
+                }
+                this.router.navigate(commands);
+            })
+        );
 
-    constructor(private actions$: Actions, private router: Router, private store: Store<AppState>) { }
+    constructor(private actions$: Actions,
+                private router: Router,
+                private store: Store<AppState>) {
+    }
 }

--- a/packages/uhk-web/src/app/store/reducers/user-configuration.ts
+++ b/packages/uhk-web/src/app/store/reducers/user-configuration.ts
@@ -1,8 +1,8 @@
 import { Action } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/map';
+import { of } from 'rxjs/observable/of';
+import { map } from 'rxjs/operators';
 
 import {
     KeyAction,
@@ -360,29 +360,37 @@ export function getKeymap(abbr: string) {
     }
 
     return (state$: Observable<AppState>) => getKeymaps()(state$)
-        .map((keymaps: Keymap[]) =>
-            keymaps.find((keymap: Keymap) => keymap.abbreviation === abbr)
+        .pipe(
+            map((keymaps: Keymap[]) =>
+                keymaps.find((keymap: Keymap) => keymap.abbreviation === abbr)
+            )
         );
 }
 
 export function getDefaultKeymap() {
     return (state$: Observable<AppState>) => getKeymaps()(state$)
-        .map((keymaps: Keymap[]) =>
-            keymaps.find((keymap: Keymap) => keymap.isDefault)
+        .pipe(
+            map((keymaps: Keymap[]) =>
+                keymaps.find((keymap: Keymap) => keymap.isDefault)
+            )
         );
 }
 
 export function getMacros(): (state$: Observable<AppState>) => Observable<Macro[]> {
     return (state$: Observable<AppState>) => state$
-        .map(state => state.userConfiguration.macros);
+        .pipe(
+            map(state => state.userConfiguration.macros)
+        );
 }
 
 export function getMacro(id: number) {
     if (isNaN(id)) {
-        return () => Observable.of<Macro>(undefined);
+        return () => of<Macro>(undefined);
     } else {
         return (state$: Observable<AppState>) => getMacros()(state$)
-            .map((macros: Macro[]) => macros.find((macro: Macro) => macro.id === id));
+            .pipe(
+                map((macros: Macro[]) => macros.find((macro: Macro) => macro.id === id))
+            );
     }
 }
 


### PR DESCRIPTION
The `let` operator was not migrated because earlier two reducers needed be refactored
- user-configuration reducer
- present reducer

This commit is prerequisite of the angular upgrade.