### PR TITLE
chore: upgrade electron => 2.0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6157,9 +6157,9 @@
       "dev": true
     },
     "electron": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.7.tgz",
-      "integrity": "sha512-q6dn8bspX8u8z6tNU4bEas6ZrdNavnrjJ6d/oz49Nb4zFIPrdh8p29AFjFlSAavypGwAVR/PhYOAGwzZSQSSVQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.16.tgz",
+      "integrity": "sha512-mlC91VDuBU8x9tdGGISznrBCsnPKO1tBskXtBQhceBt0zWUZtV6eURVF5RaY5QK5Q+eBzVJbFT4+LUVupNwhSg==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "decompress": "4.2.0",
     "decompress-tarbz2": "4.1.1",
     "devtron": "1.4.0",
-    "electron": "1.8.7",
+    "electron": "2.0.16",
     "electron-builder": "20.34.0",
     "electron-debug": "1.5.0",
     "electron-devtools-installer": "2.2.3",


### PR DESCRIPTION
I reviewed the electron changelog and it does not contain any breaking changes that have an effect to the Agent.
node-hid also compatible with this electron.

I tested the following options without any error:
- save user configuration
- upgrade firmware
