### PR TITLE
refactor: use Buffer.from and Buffer.alloc instead of new Buffer()

### DIFF
--- a/packages/kboot/src/usb-peripheral.ts
+++ b/packages/kboot/src/usb-peripheral.ts
@@ -43,8 +43,8 @@ export class UsbPeripheral implements Peripheral {
             throw new Error('USB device can not be found');
         }
 
-        this._responseBuffer = new Buffer(0);
-        this._dataBuffer = new Buffer(0);
+        this._responseBuffer = Buffer.alloc(0);
+        this._dataBuffer = Buffer.alloc(0);
 
         this._device = new HID(device.path);
         this._device.on('data', this._usbDataListener.bind(this));
@@ -228,9 +228,9 @@ export class UsbPeripheral implements Peripheral {
                     const data = buffer.slice(0, byte);
 
                     if (buffer.length === byte) {
-                        this[bufferName] = new Buffer(0);
+                        this[bufferName] = Buffer.alloc(0);
                     } else {
-                        const newDataBuffer = new Buffer(buffer.length - byte);
+                        const newDataBuffer = Buffer.alloc(buffer.length - byte);
                         buffer.copy(newDataBuffer, 0, byte);
                         this[bufferName] = newDataBuffer;
                     }
@@ -248,11 +248,11 @@ export class UsbPeripheral implements Peripheral {
     }
 
     private _resetDataBuffer(): void {
-        this._dataBuffer = new Buffer(0);
+        this._dataBuffer = Buffer.alloc(0);
     }
 
     private _resetResponseBuffer(): void {
-        this._responseBuffer = new Buffer(0);
+        this._responseBuffer = Buffer.alloc(0);
     }
 
     private async _getNextCommandResponse(): Promise<CommandResponse> {

--- a/packages/kboot/test/test-peripheral.ts
+++ b/packages/kboot/test/test-peripheral.ts
@@ -11,7 +11,7 @@ export class TestPeripheral implements Peripheral {
         const response = {
             tag: ResponseTags.Generic,
             code: ResponseCodes.Success,
-            raw: new Buffer(0)
+            raw: Buffer.alloc(0)
         };
 
         return Promise.resolve(response);
@@ -22,6 +22,6 @@ export class TestPeripheral implements Peripheral {
     }
 
     readMemory(startAddress: number, count: number): Promise<Buffer> {
-        return Promise.resolve(new Buffer(0));
+        return Promise.resolve(Buffer.alloc(0));
     }
 }

--- a/packages/uhk-agent/src/util/save-extract-firmware.ts
+++ b/packages/uhk-agent/src/util/save-extract-firmware.ts
@@ -23,7 +23,7 @@ export async function saveTmpFirmware(data: Array<number>): Promise<TmpFirmware>
 
 function writeDataToFile(data: Array<number>, filePath: string): Promise<void> {
     return new Promise((resolve, reject) => {
-        const buffer = new Buffer(data);
+        const buffer = Buffer.from(data);
 
         fs.writeFile(filePath, buffer, err => {
             if (err) {

--- a/packages/uhk-common/src/config-serializer/uhk-buffer.ts
+++ b/packages/uhk-common/src/config-serializer/uhk-buffer.ts
@@ -40,7 +40,7 @@ export class UhkBuffer {
     constructor() {
         this.offset = 0;
         this.bytesToBacktrack = 0;
-        this.buffer = new Buffer(UhkBuffer.eepromSize);
+        this.buffer = Buffer.alloc(UhkBuffer.eepromSize);
         this.buffer.fill(0);
     }
 

--- a/packages/uhk-usb/src/uhk-hid-device.ts
+++ b/packages/uhk-usb/src/uhk-hid-device.ts
@@ -145,12 +145,12 @@ export class UhkHidDevice {
     }
 
     public async writeConfigToEeprom(configBufferId: ConfigBufferId): Promise<void> {
-        await this.write(new Buffer([UsbCommand.LaunchEepromTransfer, EepromOperation.write, configBufferId]));
+        await this.write(Buffer.from([UsbCommand.LaunchEepromTransfer, EepromOperation.write, configBufferId]));
         await this.waitUntilKeyboardBusy();
     }
 
     public async enableUsbStackTest(): Promise<void> {
-        await this.write(new Buffer([UsbCommand.SetVariable, UsbVariables.testUsbStack, 1]));
+        await this.write(Buffer.from([UsbCommand.SetVariable, UsbVariables.testUsbStack, 1]));
         await this.waitUntilKeyboardBusy();
     }
 
@@ -169,7 +169,7 @@ export class UhkHidDevice {
 
     public async waitUntilKeyboardBusy(): Promise<void> {
         while (true) {
-            const buffer = await this.write(new Buffer([UsbCommand.GetDeviceState]));
+            const buffer = await this.write(Buffer.from([UsbCommand.GetDeviceState]));
             if (buffer[1] === 0) {
                 break;
             }
@@ -186,7 +186,7 @@ export class UhkHidDevice {
         const reenumMode = EnumerationModes[enumerationMode].toString();
         this.logService.debug(`[UhkHidDevice] Start reenumeration, mode: ${reenumMode}`);
 
-        const message = new Buffer([
+        const message = Buffer.from([
             UsbCommand.Reenumerate,
             enumerationMode,
             BOOTLOADER_TIMEOUT_MS & 0xff,
@@ -240,16 +240,16 @@ export class UhkHidDevice {
         const moduleName = kbootCommandName(module);
         this.logService.debug(`[UhkHidDevice] USB[T]: Send KbootCommand ${moduleName} ${KbootCommands[command].toString()}`);
         if (command === KbootCommands.idle) {
-            transfer = new Buffer([UsbCommand.SendKbootCommandToModule, command]);
+            transfer = Buffer.from([UsbCommand.SendKbootCommandToModule, command]);
         } else {
-            transfer = new Buffer([UsbCommand.SendKbootCommandToModule, command, module]);
+            transfer = Buffer.from([UsbCommand.SendKbootCommandToModule, command, module]);
         }
         await retry(async () => await this.write(transfer), maxTry, this.logService);
     }
 
     async jumpToBootloaderModule(module: ModuleSlotToId): Promise<any> {
         this.logService.debug(`[UhkHidDevice] USB[T]: Jump to bootloader. Module: ${ModuleSlotToId[module].toString()}`);
-        const transfer = new Buffer([UsbCommand.JumpToModuleBootloader, module]);
+        const transfer = Buffer.from([UsbCommand.JumpToModuleBootloader, module]);
         await this.write(transfer);
     }
 

--- a/packages/uhk-usb/src/uhk-operations.ts
+++ b/packages/uhk-usb/src/uhk-operations.ts
@@ -165,7 +165,7 @@ export class UhkOperations {
             this.logService.debug(`[DeviceOperation] getConfigSize() configSize: ${configSize}`);
             const chunkSize = 63;
             let offset = 0;
-            let configBuffer = new Buffer(0);
+            let configBuffer = Buffer.alloc(0);
             let firstRead = true;
 
             this.logService.debug(`[DeviceOperation] USB[T]: Read ${configName} from keyboard`);
@@ -174,7 +174,7 @@ export class UhkOperations {
                 const writeBuffer = Buffer.from(
                     [UsbCommand.ReadConfig, configBufferId, chunkSizeToRead, offset & 0xff, offset >> 8]);
                 const readBuffer = await this.device.write(writeBuffer);
-                configBuffer = Buffer.concat([configBuffer, new Buffer(readBuffer.slice(1, chunkSizeToRead + 1))]);
+                configBuffer = Buffer.concat([configBuffer, Buffer.from(readBuffer.slice(1, chunkSizeToRead + 1))]);
                 offset += chunkSizeToRead;
 
                 if (firstRead && configBufferId !== ConfigBufferId.hardwareConfig) {
@@ -203,7 +203,7 @@ export class UhkOperations {
      * @returns {Promise<number>}
      */
     public async getConfigSizeFromKeyboard(configBufferId: ConfigBufferId): Promise<number> {
-        const buffer = await this.device.write(new Buffer([UsbCommand.GetProperty, DevicePropertyIds.ConfigSizes]));
+        const buffer = await this.device.write(Buffer.from([UsbCommand.GetProperty, DevicePropertyIds.ConfigSizes]));
         this.device.close();
         const hardwareConfigSize = buffer[1] + (buffer[2] << 8);
         const userConfigSize = buffer[3] + (buffer[4] << 8);
@@ -232,7 +232,7 @@ export class UhkOperations {
         const timeoutTime = new Date(new Date().getTime() + 30000);
 
         while (new Date() < timeoutTime) {
-            const buffer = await this.device.write(new Buffer([UsbCommand.GetProperty, DevicePropertyIds.CurrentKbootCommand]));
+            const buffer = await this.device.write(Buffer.from([UsbCommand.GetProperty, DevicePropertyIds.CurrentKbootCommand]));
             this.device.close();
 
             if (buffer[1] === 0) {
@@ -252,7 +252,7 @@ export class UhkOperations {
         try {
             this.logService.debug('[DeviceOperation] USB[T]: Read left module version information');
 
-            const command = new Buffer([
+            const command = Buffer.from([
                 UsbCommand.GetModuleProperty,
                 ModuleSlotToId.leftHalf,
                 ModulePropertyId.protocolVersions
@@ -280,7 +280,7 @@ export class UhkOperations {
     public async getRightModuleVersionInfo(): Promise<HardwareModuleInfo> {
         this.logService.debug('[DeviceOperation] USB[T]: Read right module version information');
 
-        const command = new Buffer([UsbCommand.GetProperty, DevicePropertyIds.ProtocolVersions]);
+        const command = Buffer.from([UsbCommand.GetProperty, DevicePropertyIds.ProtocolVersions]);
         const buffer = await this.device.write(command);
         const uhkBuffer = UhkBuffer.fromArray(convertBufferToIntArray(buffer));
         // skip the first byte
@@ -303,7 +303,7 @@ export class UhkOperations {
             await this.device.write(fragment);
         }
         this.logService.debug('[DeviceOperation] USB[T]: Apply user configuration to keyboard');
-        const applyBuffer = new Buffer([UsbCommand.ApplyConfig]);
+        const applyBuffer = Buffer.from([UsbCommand.ApplyConfig]);
         await this.device.write(applyBuffer);
     }
 

--- a/packages/uhk-usb/src/util.ts
+++ b/packages/uhk-usb/src/util.ts
@@ -33,7 +33,7 @@ export function getTransferBuffers(usbCommand: UsbCommand, configBuffer: Buffer)
         const length = offset + MAX_SENDING_PAYLOAD_SIZE < configBuffer.length
             ? MAX_SENDING_PAYLOAD_SIZE
             : configBuffer.length - offset;
-        const header = new Buffer([usbCommand, length, offset & 0xFF, offset >> 8]);
+        const header = Buffer.from([usbCommand, length, offset & 0xFF, offset >> 8]);
         fragments.push(Buffer.concat([header, configBuffer.slice(offset, offset + length)]));
     }
 

--- a/packages/uhk-web/src/app/store/effects/user-config.ts
+++ b/packages/uhk-web/src/app/store/effects/user-config.ts
@@ -209,7 +209,7 @@ export class UserConfigEffects {
                     if (info.filename.endsWith('.bin')) {
                         userConfig.fromBinary(UhkBuffer.fromArray(info.data));
                     } else {
-                        const buffer = new Buffer(info.data);
+                        const buffer = Buffer.from(info.data);
                         const json = buffer.toString();
                         userConfig.fromJsonObject(JSON.parse(json));
                     }

--- a/packages/usb/blink-led-pwm-brightness.js
+++ b/packages/usb/blink-led-pwm-brightness.js
@@ -8,5 +8,5 @@ setInterval(() => {
     areLedsEnabled = !areLedsEnabled;
     const brightnessPercent = areLedsEnabled ? 100 : 0;
 
-    device.write(uhk.getTransferData(new Buffer([uhk.usbCommands.setLedPwmBrightness, brightnessPercent])));
+    device.write(uhk.getTransferData(Buffer.from([uhk.usbCommands.setLedPwmBrightness, brightnessPercent])));
 }, 500);

--- a/packages/usb/blink-test-leds.js
+++ b/packages/usb/blink-test-leds.js
@@ -7,5 +7,5 @@ const device = uhk.getUhkDevice();
 setInterval(() => {
     areLedsEnabled = !areLedsEnabled;
 
-    device.write(uhk.getTransferData(new Buffer([uhk.usbCommands.setTestLed, areLedsEnabled ? 1 : 0])));
+    device.write(uhk.getTransferData(Buffer.from([uhk.usbCommands.setTestLed, areLedsEnabled ? 1 : 0])));
 }, 500);

--- a/packages/usb/erase-user-config.js
+++ b/packages/usb/erase-user-config.js
@@ -4,7 +4,7 @@ const uhk = require('./uhk');
 
 (async function() {
     const device = uhk.getUhkDevice();
-    const buffer = new Buffer(Array(2**15-64).fill(0xff));
+    const buffer = Buffer.from(Array(2**15-64).fill(0xff));
     await uhk.writeConfig(device, buffer, false);
     await uhk.launchEepromTransfer(device, uhk.eepromOperations.write, uhk.configBufferIds.stagingUserConfig);
 })();

--- a/packages/usb/get-adc-value.js
+++ b/packages/usb/get-adc-value.js
@@ -4,7 +4,7 @@ const uhk = require('./uhk');
 const device = uhk.getUhkDevice();
 
 function getAdcValue() {
-    const data = uhk.getTransferData(new Buffer([uhk.usbCommands.getAdcValue]));
+    const data = uhk.getTransferData(Buffer.from([uhk.usbCommands.getAdcValue]));
     console.log('Sending ', data);
     device.write(data);
     const receivedBuffer = Buffer.from(device.readSync());

--- a/packages/usb/get-config-size.js
+++ b/packages/usb/get-config-size.js
@@ -2,7 +2,7 @@
 const uhk = require('./uhk');
 
 const device = uhk.getUhkDevice();
-const sendData = new Buffer([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.configSizes]);
+const sendData = Buffer.from([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.configSizes]);
 device.write(uhk.getTransferData(sendData));
 const response = Buffer.from(device.readSync());
 

--- a/packages/usb/get-debug-info.js
+++ b/packages/usb/get-debug-info.js
@@ -13,7 +13,7 @@ function getUint16(buffer, offset) {
 let prevGeneric, prevBasic, prevMedia, prevSystem, prevMouse;
 function getDebugInfo() {
 
-    const payload = new Buffer([uhk.usbCommands.getDebugBuffer]);
+    const payload = Buffer.from([uhk.usbCommands.getDebugBuffer]);
 //    console.log(payload)
 //    console.log('Sending ', uhk.bufferToString(payload));
     device.write(uhk.getTransferData(payload));

--- a/packages/usb/get-device-state.js
+++ b/packages/usb/get-device-state.js
@@ -3,7 +3,7 @@ const uhk = require('./uhk');
 const device = uhk.getUhkDevice();
 
 function readKeyboardState() {
-    const payload = new Buffer([uhk.usbCommands.getDeviceState]);
+    const payload = Buffer.from([uhk.usbCommands.getDeviceState]);
     console.log('Sending ', uhk.bufferToString(payload));
     device.write(uhk.getTransferData(payload));
     const receivedBuffer = device.readSync();

--- a/packages/usb/get-i2c-health.js
+++ b/packages/usb/get-i2c-health.js
@@ -51,20 +51,20 @@ function convertMs(milliseconds) {
 
 const device = uhk.getUhkDevice();
 
-device.write(uhk.getTransferData(new Buffer([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.uptime])));
+device.write(uhk.getTransferData(Buffer.from([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.uptime])));
 let response = device.readSync();
 let uptimeMs = uhk.getUint32(response, 1);
 let uptime = convertMs(uptimeMs);
 console.log(`uptime: ${uptime.days}d ${String(uptime.hours).padStart(2, '0')}:${String(uptime.minutes).padStart(2, '0')}:${String(uptime.seconds).padStart(2, '0')}`)
 
-device.write(uhk.getTransferData(new Buffer([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.i2cBaudRate])));
+device.write(uhk.getTransferData(Buffer.from([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.i2cBaudRate])));
 response = device.readSync();
 let requestedBaudRate = uhk.getUint32(response, 2);
 let actualBaudRate = uhk.getUint32(response, 6);
 console.log(`requestedBaudRate:${requestedBaudRate} | actualBaudRate:${actualBaudRate} | I2C0_F:0b${response[1].toString(2).padStart(8, '0')}`)
 
 for (let slaveId=0; slaveId<6; slaveId++) {
-    device.write(uhk.getTransferData(new Buffer([uhk.usbCommands.getSlaveI2cErrors, slaveId])));
+    device.write(uhk.getTransferData(Buffer.from([uhk.usbCommands.getSlaveI2cErrors, slaveId])));
     let response = Buffer.from(device.readSync());
     let str = slaveI2cErrorBufferToString(response, slaveId);
     console.log(str);

--- a/packages/usb/get-left-firmware-version.js
+++ b/packages/usb/get-left-firmware-version.js
@@ -2,7 +2,7 @@
 const uhk = require('./uhk');
 
 const device = uhk.getUhkDevice();
-const sendData = new Buffer([uhk.usbCommands.getModuleProperty, uhk.moduleSlotToId.leftHalf, uhk.modulePropertyIds.protocolVersions]);
+const sendData = Buffer.from([uhk.usbCommands.getModuleProperty, uhk.moduleSlotToId.leftHalf, uhk.modulePropertyIds.protocolVersions]);
 //console.log(sendData)
 device.write(uhk.getTransferData(sendData));
 const response = Buffer.from(device.readSync());

--- a/packages/usb/get-right-firmware-version.js
+++ b/packages/usb/get-right-firmware-version.js
@@ -2,7 +2,7 @@
 const uhk = require('./uhk');
 
 const device = uhk.getUhkDevice();
-const sendData = new Buffer([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.protocolVersions]);
+const sendData = Buffer.from([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.protocolVersions]);
 //console.log(sendData)
 device.write(uhk.getTransferData(sendData));
 const response = Buffer.from(device.readSync());

--- a/packages/usb/get-slave-i2c-errors.js
+++ b/packages/usb/get-slave-i2c-errors.js
@@ -5,7 +5,7 @@ const uhk = require('./uhk');
 const slaveId = parseInt(process.argv[2]);
 
 const device = uhk.getUhkDevice();
-const sendData = new Buffer([uhk.usbCommands.getSlaveI2cErrors, slaveId]);
+const sendData = Buffer.from([uhk.usbCommands.getSlaveI2cErrors, slaveId]);
 device.write(uhk.getTransferData(sendData));
 const response = Buffer.from(device.readSync());
 

--- a/packages/usb/get-uptime.js
+++ b/packages/usb/get-uptime.js
@@ -15,7 +15,7 @@ function convertMs(milliseconds) {
     return {days, hours, minutes, seconds};
 }
 
-let buffer = new Buffer([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.uptime]);
+let buffer = Buffer.from([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.uptime]);
 //console.log(buffer);
 device.write(uhk.getTransferData(buffer));
 let response = device.readSync();

--- a/packages/usb/hidapi-sync-stress-test.js
+++ b/packages/usb/hidapi-sync-stress-test.js
@@ -6,7 +6,7 @@ let counter = 1;
 
 while (true) {
     console.log(`hidapi sync test ${counter++}`);
-    const sendData = new Buffer([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.configSizes]);
+    const sendData = Buffer.from([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.configSizes]);
     device.write(uhk.getTransferData(sendData));
     device.readSync()
 }

--- a/packages/usb/read-config.js
+++ b/packages/usb/read-config.js
@@ -7,10 +7,10 @@ const chunkSize = 63;
 let isHardwareConfig = process.argv[2] === 'h';
 let configTypeString = isHardwareConfig ? 'hardware' : 'user';
 let offset = 0;
-let configBuffer = new Buffer(0);
+let configBuffer = Buffer.alloc(0);
 let chunkSizeToRead;
 
-const payload = new Buffer([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.configSizes]);
+const payload = Buffer.from([uhk.usbCommands.getDeviceProperty, uhk.devicePropertyIds.configSizes]);
 device.write(uhk.getTransferData(payload));
 let buffer = Buffer.from(device.readSync());
 const hardwareConfigMaxSize = buffer[1] + (buffer[2]<<8);
@@ -27,7 +27,7 @@ while (offset < configSize) {
     device.write(uhk.getTransferData(buffer));
     buffer = Buffer.from(device.readSync());
     console.log('read-config-chunk', uhk.bufferToString(buffer));
-    configBuffer = Buffer.concat([configBuffer, new Buffer(buffer.slice(1, chunkSizeToRead + 1))]);
+    configBuffer = Buffer.concat([configBuffer, Buffer.from(buffer.slice(1, chunkSizeToRead + 1))]);
     offset += chunkSizeToRead
 }
 console.log('read ', uhk.bufferToString(configBuffer));

--- a/packages/usb/set-led-pwm-brightness.js
+++ b/packages/usb/set-led-pwm-brightness.js
@@ -10,4 +10,4 @@ if (process.argv.length !== 3) {
 }
 
 let leftBrightnessPercent = process.argv[2] || '';
-device.write(uhk.getTransferData(new Buffer([uhk.usbCommands.setLedPwmBrightness, +leftBrightnessPercent])));
+device.write(uhk.getTransferData(Buffer.from([uhk.usbCommands.setLedPwmBrightness, +leftBrightnessPercent])));

--- a/packages/usb/uhk.js
+++ b/packages/usb/uhk.js
@@ -43,7 +43,7 @@ function uint32ToArray(value) {
 }
 
 function writeDevice(device, data, options={}) {
-    const dataBuffer = new Buffer(data);
+    const dataBuffer = Buffer.from(data);
     if (!options.noDebug) {
         writeLog('W: ', dataBuffer);
     }
@@ -396,7 +396,7 @@ async function writeHca(device, isIso) {
 }
 
 async function eraseHca(device) {
-    const buffer = new Buffer(Array(64).fill(0xff));
+    const buffer = Buffer.from(Array(64).fill(0xff));
     await uhk.writeConfig(device, buffer, true);
     await uhk.launchEepromTransfer(device, uhk.eepromOperations.write, configBufferIds.hardwareConfig);
 }


### PR DESCRIPTION
The `new Buffer()` is deprecated and vulnerable.
The upgrade is prerequisite of the Electron 3.x upgrade