### PR TITLE
chore: use fs-extra instead of mkdirp package

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "jsonfile": "4.0.0",
     "lerna": "3.16.1",
     "lodash": "4.17.15",
-    "mkdirp": "0.5.1",
     "node-hid": "0.7.8",
     "npm-run-all": "4.0.2",
     "nrf-intel-hex": "1.3.0",

--- a/scripts/generate-svg-sprites.js
+++ b/scripts/generate-svg-sprites.js
@@ -1,7 +1,7 @@
 const SVGSpriter = require('svg-sprite');
 const path = require('path');
-const mkdirp = require('mkdirp');
-const fs = require('fs');
+const fs = require('fs-extra');
+
 let config = {
     'dest': 'packages/uhk-web/src/assets/',
     log: 'verbose',
@@ -90,7 +90,7 @@ function writeResultFiles (error, result) {
 
         // Run through all created resources and write them to disk
         for (const type in result[mode]) {
-            mkdirp.sync(path.dirname(result[mode][type].path));
+            fs.ensureDirSync(path.dirname(result[mode][type].path));
             fs.writeFileSync(result[mode][type].path, result[mode][type].contents);
         }
     }


### PR DESCRIPTION
The fs-extra has the same `ensureDirSync` function that functionality is the same than `mkdirp`. It decreases the direct dependencies of the Agent