### PR TITLE
chore(usb): add kboot-firmware-upgrade script

### DIFF
--- a/packages/uhk-usb/src/util.ts
+++ b/packages/uhk-usb/src/util.ts
@@ -1,7 +1,7 @@
 import { Device, devices } from 'node-hid';
 import { readFile } from 'fs-extra';
 import { EOL } from 'os';
-import MemoryMap from 'nrf-intel-hex';
+import * as MemoryMap from 'nrf-intel-hex';
 import { LogService } from 'uhk-common';
 
 import { Constants, UsbCommand } from './constants';

--- a/packages/usb/kboot-firmware-upgrade.ts
+++ b/packages/usb/kboot-firmware-upgrade.ts
@@ -1,0 +1,17 @@
+import * as path from 'path';
+import { LogService } from 'uhk-common';
+import { UhkHidDevice, UhkOperations } from 'uhk-usb';
+
+const logService = new LogService();
+const rootDir = path.join(__dirname, '../../tmp');
+const uhkHidDevice = new UhkHidDevice(logService, {}, rootDir);
+const uhkOperations = new UhkOperations(logService, uhkHidDevice, rootDir);
+
+uhkOperations
+    .updateRightFirmware()
+    .then(() => uhkOperations.updateLeftModule())
+    .then(() => console.log('Firmware upgrade finished'))
+    .catch(error => {
+        console.error(error);
+        process.exit(-1);
+    });


### PR DESCRIPTION
With this script, we can test the new kboot firmware upgrade without new release

run the following command in the agent root directory:
`$ node -r ts-node/register -r source-map-support/register packages/usb/kboot-firmware-upgrade.ts`