### PR TITLE
Fix MemoryMap import

### DIFF
--- a/packages/uhk-usb/src/util.ts
+++ b/packages/uhk-usb/src/util.ts
@@ -1,7 +1,7 @@
 import { Device, devices } from 'node-hid';
 import { readFile } from 'fs-extra';
 import { EOL } from 'os';
-import * as MemoryMap from 'nrf-intel-hex';
+import MemoryMap from 'nrf-intel-hex';
 import { LogService } from 'uhk-common';
 
 import { Constants, UsbCommand } from './constants';


### PR DESCRIPTION
Flashing the keyboard firmware was erroring and this (temporarily) bricked my keyboard. This is how I fixed it.

Here's a snippet of the errors I was getting:

```
[15:07:33.197] [debug] [UhkOperations] Read RIGHT firmware from file
[15:07:33.758] [error] [DeviceService] updateFirmware error { message: 'a.fromHex is not a function',
  stack:
   'TypeError: a.fromHex is not a function\n    at Object.<anonymous> (/usr/local/google/home/tmandry/code/tools/agent/packages/uhk-agent/dist/webpack:/uhk-usb/dist/src/util.js:123:1)\n    at Generator.next (<anonymous>)\n    at s (/usr/local/google/home/tmandry/code/tools/agent/packages/uhk-agent/dist/webpack:/uhk-usb/node_modules/tslib/tslib.es6.js:70:42)' }
[15:07:33.761] [debug] [UhkHidDevice] Available devices:
[15:07:33.762] [debug] {"vendorId":7504,"productId":24864,"path":"/dev/hidraw1","serialNumber":"","manufacturer":"Ultimate Gadget Laboratories","product":"UHK Bootloader","release":2,"interface":0,"usagePage":1760,"usage":23104}
[15:07:33.762] [debug] [UhkHidDevice] UHK Device not found:
[15:07:33.762] [error] [DeviceService] Read hardware modules information failed Error: [UhkHidDevice] Device is not connected
    at Promise (/usr/local/google/home/tmandry/code/tools/agent/packages/uhk-agent/dist/webpack:/uhk-usb/dist/src/uhk-hid-device.js:107:1)
    at new Promise (<anonymous>)
    at t.UhkHidDevice.<anonymous> (/usr/local/google/home/tmandry/code/tools/agent/packages/uhk-agent/dist/webpack:/uhk-usb/dist/src/uhk-hid-device.js:104:1)
    at Generator.next (<anonymous>)
    at /usr/local/google/home/tmandry/code/tools/agent/packages/uhk-agent/dist/webpack:/uhk-usb/node_modules/tslib/tslib.es6.js:73:1
    at new Promise (<anonymous>)
    at Module.l (/usr/local/google/home/tmandry/code/tools/agent/packages/uhk-agent/dist/webpack:/uhk-usb/node_modules/tslib/tslib.es6.js:69:1)
    at t.UhkHidDevice.write (/usr/local/google/home/tmandry/code/tools/agent/packages/uhk-agent/dist/webpack:/uhk-usb/dist/src/uhk-hid-device.js:103:1)
    at t.UhkHidDevice.<anonymous> (/usr/local/google/home/tmandry/code/tools/agent/packages/uhk-agent/dist/webpack:/uhk-usb/dist/src/uhk-hid-device.js:155:1)
    at Generator.next (<anonymous>)
```