### PR TITLE
chore: use preserveWhitespaces = true in electron renderer build

### DIFF
--- a/packages/uhk-web/src/main-renderer.ts
+++ b/packages/uhk-web/src/main-renderer.ts
@@ -8,4 +8,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(UhkRendererModule);
+platformBrowserDynamic().bootstrapModule(UhkRendererModule, {
+    preserveWhitespaces: true
+});


### PR DESCRIPTION
The `npm run server:electron` build result much more simmilar to the production build