### PR TITLE
fix: allowed file extension for the firmware file upload

### DIFF
--- a/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.html
+++ b/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.html
@@ -23,7 +23,7 @@
                 </button>
                 <file-upload [disabled]="flashFirmwareButtonDisbabled$ | async"
                              (fileChanged)="changeFile($event)"
-                             accept=".tar.bz2"
+                             accept=".bz2"
                              label="Choose firmware file and flash it"></file-upload>
             </p>
 


### PR DESCRIPTION
The `.tar.bz2` value does not allow selecting the firmware file on Mac