### PR TITLE
feat: Use native kboot firmware update on Linux and Mac. Use blhost on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "server:electron": "lerna exec --scope uhk-web npm run server:renderer",
     "electron": "lerna exec --scope uhk-agent npm start",
     "electron:spe": "lerna exec --scope uhk-agent npm run electron:spe",
+    "electron:blhost": "lerna exec --scope uhk-agent npm run electron:blhost",
     "electron:kboot": "lerna exec --scope uhk-agent npm run electron:kboot",
     "pack": "node ./scripts/release.js",
     "sprites": "node ./scripts/generate-svg-sprites",

--- a/packages/uhk-agent/package.json
+++ b/packages/uhk-agent/package.json
@@ -29,7 +29,8 @@
   "scripts": {
     "start": "cross-env DEBUG=kboot* electron ./dist/electron-main.js",
     "electron:spe": "electron ./dist/electron-main.js --spe",
-    "electron:kboot": "cross-env DEBUG=kboot* electron ./dist/electron-main.js --useKboot",
+    "electron:blhost": "electron ./dist/electron-main.js --usbDriver=blhost",
+    "electron:kboot": "cross-env DEBUG=kboot* electron ./dist/electron-main.js --usbDriver=kboot",
     "build": "webpack && npm run install:build-deps && npm run build:usb && npm run download-firmware && npm run copy-to-tmp-folder",
     "build:usb": "electron-rebuild -w node-hid -p -m ./dist",
     "lint": "tslint --project tsconfig.json",

--- a/packages/uhk-agent/src/electron-main.ts
+++ b/packages/uhk-agent/src/electron-main.ts
@@ -24,7 +24,7 @@ import { loadWindowState, saveWindowState } from './util/window';
 const optionDefinitions = [
     {name: 'addons', type: Boolean},
     {name: 'spe', type: Boolean}, // simulate privilege escalation error
-    {name: 'useKboot', type: Boolean} // If it is true use kboot package instead of blhost for firmware upgrade
+    {name: 'usbDriver', type: String}
 ];
 
 const options: CommandLineArgs = commandLineArgs(optionDefinitions);

--- a/packages/uhk-common/src/models/command-line-args.ts
+++ b/packages/uhk-common/src/models/command-line-args.ts
@@ -8,7 +8,7 @@ export interface CommandLineArgs {
      */
     spe?: boolean;
     /**
-     * If it is true use kboot package instead of blhost for firmware upgrade
+     * The driver which is used for firmware upgrade
      */
-    useKboot?: boolean;
+    usbDriver?: 'blhost' | 'kboot';
 }


### PR DESCRIPTION
close: #1042 