### PR TITLE
chore: upgrade electron-log => 3.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5291,9 +5291,9 @@
       }
     },
     "electron-log": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-2.2.16.tgz",
-      "integrity": "sha512-0zFLIJ7lMuM/HBbsHDp57RevuyMJxyfMD8KnN5z0A7gmoWJR/iqX00z/aSjQAY2OGLK7I5TpgGYhEt9crt9Z1w==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-3.0.8.tgz",
+      "integrity": "sha512-B9+eJ8z3UbDnWEz+G33SIJvEDeKLznHEV4sCu6bR31KuOdp3dYN046QBWbLNsvKU+lzFI6eOi+xNCpNHZvatiw==",
       "dev": true
     },
     "electron-notarize": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "electron-builder": "21.2.0",
     "electron-debug": "1.5.0",
     "electron-devtools-installer": "2.2.3",
-    "electron-log": "2.2.16",
+    "electron-log": "3.0.8",
     "electron-notarize": "0.1.1",
     "electron-rebuild": "1.8.6",
     "electron-settings": "3.1.4",


### PR DESCRIPTION
It is a major version change and changing the log output format.
File log entry example
[2019-11-01 21:43:49.550] [debug] [UhkHidDevice] USB[W]: 09 
Console log entry format
21:49:15.115 › [UhkHidDevice] USB[W]: 09 
