### PR TITLE
refactor: rename AutoUpdateSettings => ApplicationSettings

### DIFF
--- a/packages/uhk-agent/src/services/app-update.service.ts
+++ b/packages/uhk-agent/src/services/app-update.service.ts
@@ -1,11 +1,11 @@
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { UpdateInfo, ProgressInfo } from 'builder-util-runtime';
 import * as settings from 'electron-settings';
 import * as isDev from 'electron-is-dev';
 import * as storage from 'electron-settings';
 
-import { AutoUpdateSettings, IpcEvents, LogService } from 'uhk-common';
+import { ApplicationSettings, IpcEvents, LogService } from 'uhk-common';
 import { MainServiceBase } from './main-service-base';
 
 export class AppUpdateService extends MainServiceBase {
@@ -131,18 +131,17 @@ export class AppUpdateService extends MainServiceBase {
     }
 
     private checkForUpdateAtStartup() {
-        const autoUpdateSettings = this.getAutoUpdateSettings();
-        const checkForUpdate = autoUpdateSettings && autoUpdateSettings.checkForUpdateOnStartUp;
+        const { checkForUpdateOnStartUp = true } = this.getApplicationSettings();
 
-        this.logService.debug('[AppUpdateService] check for update at startup:', {checkForUpdate, autoUpdateSettings});
+        this.logService.debug('[AppUpdateService] check for update at startup:', { checkForUpdateOnStartUp });
 
-        return checkForUpdate;
+        return checkForUpdateOnStartUp;
     }
 
-    private getAutoUpdateSettings(): AutoUpdateSettings {
-        const value = storage.get('auto-update-settings');
+    private getApplicationSettings(): ApplicationSettings {
+        const value = storage.get('application-settings');
         if (!value) {
-            return {checkForUpdateOnStartUp: false};
+            return {checkForUpdateOnStartUp: true};
         }
 
         return JSON.parse(<string>value);

--- a/packages/uhk-common/src/models/application-settings.ts
+++ b/packages/uhk-common/src/models/application-settings.ts
@@ -1,0 +1,3 @@
+export interface ApplicationSettings {
+    checkForUpdateOnStartUp: boolean;
+}

--- a/packages/uhk-common/src/models/auto-update-settings.ts
+++ b/packages/uhk-common/src/models/auto-update-settings.ts
@@ -1,4 +1,0 @@
-export interface AutoUpdateSettings {
-    checkForUpdateOnStartUp: boolean;
-    usePreReleaseUpdate?: boolean;
-}

--- a/packages/uhk-common/src/models/index.ts
+++ b/packages/uhk-common/src/models/index.ts
@@ -1,4 +1,4 @@
-export * from './auto-update-settings';
+export * from './application-settings';
 export * from './command-line-args';
 export * from './notification';
 export * from './ipc-response';

--- a/packages/uhk-web/src/app/components/agent/settings/settings.component.html
+++ b/packages/uhk-web/src/app/components/agent/settings/settings.component.html
@@ -4,8 +4,7 @@
         <span class="macro__name pane-title__name">Settings</span>
     </h1>
 </div>
-<auto-update-settings [settings]="autoUpdateSettings$ | async"
-                      [checkingForUpdate]="checkingForUpdate$ | async"
-                      (toggleCheckForUpdateOnStartUp)="toogleCheckForUpdateOnStartUp($event)"
+<auto-update-settings [state]="updateSettingsState$ | async"
+                      (toggleCheckForUpdateOnStartUp)="toggleCheckForUpdateOnStartUp($event)"
                       (checkForUpdate)="checkForUpdate($event)">
 </auto-update-settings>

--- a/packages/uhk-web/src/app/components/agent/settings/settings.component.ts
+++ b/packages/uhk-web/src/app/components/agent/settings/settings.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
-import { AutoUpdateSettings } from 'uhk-common';
 
-import { AppState, getAutoUpdateSettings, getCheckingForUpdate } from '../../../store';
+import { AppState, appUpdateSettingsState } from '../../../store';
+import { State as UpdateSettingsState } from '../../../store/reducers/auto-update-settings';
 import {
     CheckForUpdateNowAction,
     ToggleCheckForUpdateOnStartupAction
@@ -18,15 +18,13 @@ import {
     }
 })
 export class SettingsComponent {
-    autoUpdateSettings$: Observable<AutoUpdateSettings>;
-    checkingForUpdate$: Observable<boolean>;
+    updateSettingsState$: Observable<UpdateSettingsState>;
 
     constructor(private store: Store<AppState>) {
-        this.autoUpdateSettings$ = store.select(getAutoUpdateSettings);
-        this.checkingForUpdate$ = store.select(getCheckingForUpdate);
+        this.updateSettingsState$ = store.select(appUpdateSettingsState);
     }
 
-    toogleCheckForUpdateOnStartUp(value: boolean) {
+    toggleCheckForUpdateOnStartUp(value: boolean) {
         this.store.dispatch(new ToggleCheckForUpdateOnStartupAction(value));
     }
 

--- a/packages/uhk-web/src/app/components/auto-update-settings/auto-update-settings.html
+++ b/packages/uhk-web/src/app/components/auto-update-settings/auto-update-settings.html
@@ -3,7 +3,7 @@
         <div class="checkbox">
             <label>
                 <input type="checkbox"
-                       [checked]="settings.checkForUpdateOnStartUp"
+                       [checked]="state.checkForUpdateOnStartUp"
                        (change)="emitCheckForUpdateOnStartUp($event.target.checked)"> Automatically check for update on
                 application start
             </label>
@@ -11,7 +11,7 @@
 
         <button class="btn btn-link" (click)="emitCheckForUpdate($event)">
             Check for update
-            <span *ngIf="checkingForUpdate"
+            <span *ngIf="state.checkingForUpdate"
                   class="fa fa-spinner fa-spin"></span>
         </button>
     </div>

--- a/packages/uhk-web/src/app/components/auto-update-settings/auto-update-settings.ts
+++ b/packages/uhk-web/src/app/components/auto-update-settings/auto-update-settings.ts
@@ -9,8 +9,7 @@ import { State } from '../../store/reducers/auto-update-settings';
 })
 export class AutoUpdateSettings {
 
-    @Input() settings: State | undefined;
-    @Input() checkingForUpdate: boolean;
+    @Input() state: State;
 
     @Output() toggleCheckForUpdateOnStartUp = new EventEmitter<boolean>();
     @Output() checkForUpdate = new EventEmitter<boolean>();

--- a/packages/uhk-web/src/app/services/datastorage-repository.service.ts
+++ b/packages/uhk-web/src/app/services/datastorage-repository.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AutoUpdateSettings, UserConfiguration } from 'uhk-common';
+import { ApplicationSettings, UserConfiguration } from 'uhk-common';
 
 @Injectable()
 export class DataStorageRepositoryService {
@@ -12,11 +12,11 @@ export class DataStorageRepositoryService {
         localStorage.setItem('config', JSON.stringify(config.toJsonObject()));
     }
 
-    getAutoUpdateSettings(): AutoUpdateSettings {
-        return JSON.parse(localStorage.getItem('auto-update-settings'));
+    getApplicationSettings(): ApplicationSettings {
+        return JSON.parse(localStorage.getItem('application-settings'));
     }
 
-    saveAutoUpdateSettings(settings: AutoUpdateSettings): void {
-        localStorage.setItem('auto-update-settings', JSON.stringify(settings));
+    saveApplicationSettings(settings: ApplicationSettings): void {
+        localStorage.setItem('application-settings', JSON.stringify(settings));
     }
 }

--- a/packages/uhk-web/src/app/store/actions/app.ts
+++ b/packages/uhk-web/src/app/store/actions/app.ts
@@ -1,6 +1,6 @@
 import { Action } from '@ngrx/store';
 
-import { AppStartInfo, HardwareConfiguration, Notification } from 'uhk-common';
+import { ApplicationSettings, AppStartInfo, HardwareConfiguration, Notification } from 'uhk-common';
 import { ElectronLogEntry } from '../../models/xterm-log';
 
 export enum ActionTypes {
@@ -13,6 +13,9 @@ export enum ActionTypes {
     UndoLastSuccess = '[app] undo last action success',
     DismissUndoNotification = '[app] dismiss notification action',
     LoadHardwareConfigurationSuccess = '[app] load hardware configuration success',
+    LoadApplicationSettings = '[app] Load application settings',
+    LoadApplicationSettingsSuccess = '[app] Load application settings success',
+    SaveApplicationSettingsSuccess = '[app] Save application settings success',
     ElectronMainLogReceived = '[app] Electron main log received',
     OpenUrlInNewWindow = '[app] Open URL in new Window',
     PrivilegeWhatWillThisDo = '[app] What will this do clicked',
@@ -75,6 +78,21 @@ export class LoadHardwareConfigurationSuccessAction implements Action {
     }
 }
 
+export class LoadApplicationSettingsAction implements Action {
+    type = ActionTypes.LoadApplicationSettings;
+}
+
+export class LoadApplicationSettingsSuccessAction implements Action {
+    type = ActionTypes.LoadApplicationSettingsSuccess;
+
+    constructor(public payload: ApplicationSettings) {
+    }
+}
+
+export class SaveApplicationSettingsSuccessAction implements Action {
+    type = ActionTypes.SaveApplicationSettingsSuccess;
+}
+
 export class ElectronMainLogReceivedAction implements Action {
     type = ActionTypes.ElectronMainLogReceived;
 
@@ -134,6 +152,9 @@ export type Actions
     | UndoLastSuccessAction
     | DismissUndoNotificationAction
     | LoadHardwareConfigurationSuccessAction
+    | LoadApplicationSettingsAction
+    | LoadApplicationSettingsSuccessAction
+    | SaveApplicationSettingsSuccessAction
     | ElectronMainLogReceivedAction
     | OpenUrlInNewWindowAction
     | PrivilegeWhatWillThisDoAction

--- a/packages/uhk-web/src/app/store/actions/auto-update-settings.ts
+++ b/packages/uhk-web/src/app/store/actions/auto-update-settings.ts
@@ -1,16 +1,10 @@
 import { Action } from '@ngrx/store';
 
-import { AutoUpdateSettings } from 'uhk-common';
-
 export enum ActionTypes {
     ToggleCheckForUpdateOnStartup = '[app-update-config] Check for update on startup',
     CheckForUpdateNow = '[app-update-config] Check for update now',
     CheckForUpdateSuccess = '[app-update-config] Check for update success',
-    CheckForUpdateFailed = '[app-update-config] Check for update failed',
-    TogglePreReleaseFlag = '[app-update-config] Toggle pre release update flag',
-    LoadAutoUpdateSettings = '[app-update-config] Load auto update settings',
-    LoadAutoUpdateSettingSuccess = '[app-update-config] Load auto update settings success',
-    SaveAutoUpdateSettingSuccess = '[app-update-config] Save auto update settings success'
+    CheckForUpdateFailed = '[app-update-config] Check for update failed'
 }
 
 export class ToggleCheckForUpdateOnStartupAction implements Action {
@@ -41,34 +35,9 @@ export class CheckForUpdateFailedAction implements Action {
     }
 }
 
-export class TogglePreReleaseFlagAction implements Action {
-    type = ActionTypes.TogglePreReleaseFlag;
-
-    constructor(public payload: boolean) {
-    }
-}
-
-export class LoadAutoUpdateSettingsAction implements Action {
-    type = ActionTypes.LoadAutoUpdateSettingSuccess;
-}
-
-export class LoadAutoUpdateSettingsSuccessAction implements Action {
-    type = ActionTypes.LoadAutoUpdateSettingSuccess;
-
-    constructor(public payload: AutoUpdateSettings) {
-    }
-}
-
-export class SaveAutoUpdateSettingsSuccessAction implements Action {
-    type = ActionTypes.SaveAutoUpdateSettingSuccess;
-}
-
 export type Actions
     = ToggleCheckForUpdateOnStartupAction
     | CheckForUpdateNowAction
     | CheckForUpdateSuccessAction
     | CheckForUpdateFailedAction
-    | TogglePreReleaseFlagAction
-    | LoadAutoUpdateSettingsAction
-    | LoadAutoUpdateSettingsSuccessAction
-    | SaveAutoUpdateSettingsSuccessAction;
+    ;

--- a/packages/uhk-web/src/app/store/effects/auto-update-settings.ts
+++ b/packages/uhk-web/src/app/store/effects/auto-update-settings.ts
@@ -1,49 +1,21 @@
 import { Injectable } from '@angular/core';
 import { Actions, Effect, ofType } from '@ngrx/effects';
-import { Observable, of } from 'rxjs';
-import { Action, Store } from '@ngrx/store';
-import { map, startWith, switchMap, withLatestFrom } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { Action } from '@ngrx/store';
+import { map } from 'rxjs/operators';
 
-import { AutoUpdateSettings, NotificationType } from 'uhk-common';
+import { NotificationType } from 'uhk-common';
 
 import {
     ActionTypes,
-    LoadAutoUpdateSettingsAction,
-    LoadAutoUpdateSettingsSuccessAction,
-    SaveAutoUpdateSettingsSuccessAction,
     CheckForUpdateSuccessAction,
     CheckForUpdateFailedAction
 } from '../actions/auto-update-settings';
 
-import { DataStorageRepositoryService } from '../../services/datastorage-repository.service';
-import { AppState, getAutoUpdateSettings } from '../index';
-import { initialState } from '../reducers/auto-update-settings';
 import { ShowNotificationAction } from '../actions/app';
 
 @Injectable()
 export class AutoUpdateSettingsEffects {
-    @Effect() loadUserConfig$: Observable<Action> = this.actions$
-        .pipe(
-            ofType(ActionTypes.LoadAutoUpdateSettings),
-            startWith(new LoadAutoUpdateSettingsAction()),
-            switchMap(() => {
-                let settings: AutoUpdateSettings = this.dataStorageRepository.getAutoUpdateSettings();
-                if (!settings) {
-                    settings = initialState;
-                }
-                return of(new LoadAutoUpdateSettingsSuccessAction(settings));
-            })
-        );
-
-    @Effect() saveAutoUpdateConfig$: Observable<Action> = this.actions$
-        .pipe(
-            ofType(ActionTypes.ToggleCheckForUpdateOnStartup, ActionTypes.TogglePreReleaseFlag),
-            withLatestFrom(this.store.select(getAutoUpdateSettings)),
-            map(([action, config]) => {
-                this.dataStorageRepository.saveAutoUpdateSettings(config);
-                return new SaveAutoUpdateSettingsSuccessAction();
-            })
-        );
 
     @Effect() sendNotification$: Observable<Action> = this.actions$
         .pipe(
@@ -58,8 +30,6 @@ export class AutoUpdateSettingsEffects {
             })
         );
 
-    constructor(private actions$: Actions,
-                private dataStorageRepository: DataStorageRepositoryService,
-                private store: Store<AppState>) {
+    constructor(private actions$: Actions) {
     }
 }

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -1,7 +1,7 @@
 import { ActionReducerMap, createSelector, MetaReducer } from '@ngrx/store';
 import { routerReducer, RouterReducerState } from '@ngrx/router-store';
 import { storeFreeze } from 'ngrx-store-freeze';
-import { HardwareModules, Keymap, UserConfiguration, PlayMacroAction } from 'uhk-common';
+import { ApplicationSettings, HardwareModules, Keymap, UserConfiguration, PlayMacroAction } from 'uhk-common';
 
 import * as fromUserConfig from './reducers/user-configuration';
 import * as fromPreset from './reducers/preset';
@@ -87,8 +87,6 @@ export const getShowAppUpdateAvailable = createSelector(appUpdateState, fromAppU
 export const getUpdateInfo = createSelector(appUpdateState, fromAppUpdate.getUpdateInfo);
 
 export const appUpdateSettingsState = (state: AppState) => state.autoUpdateSettings;
-export const getAutoUpdateSettings = createSelector(appUpdateSettingsState, autoUpdateSettings.getUpdateSettings);
-export const getCheckingForUpdate = createSelector(appUpdateSettingsState, autoUpdateSettings.checkingForUpdate);
 
 export const deviceState = (state: AppState) => state.device;
 export const deviceConnected = createSelector(
@@ -200,3 +198,11 @@ export const layerDoubleTapSupported = createSelector(
 export const extraMouseButtonsSupported = createSelector(getHardwareModules, (hardwareModules: HardwareModules): boolean => {
     return isVersionGte(hardwareModules.rightModuleInfo.userConfigVersion, '4.1.1');
 });
+
+export const getApplicationSettings = createSelector(
+    appUpdateSettingsState,
+    (updateSettingsState): ApplicationSettings => {
+        return {
+            checkForUpdateOnStartUp: updateSettingsState.checkForUpdateOnStartUp
+        };
+    });

--- a/packages/uhk-web/src/app/store/reducers/app-update.reducer.ts
+++ b/packages/uhk-web/src/app/store/reducers/app-update.reducer.ts
@@ -31,7 +31,10 @@ export function reducer(state = initialState, action: AppUpdate.Actions) {
             return {
                 ...state,
                 updateDownloaded: true,
-                updateInfo: (action as UpdateDownloadedAction).payload
+                updateInfo: (action as UpdateDownloadedAction).payload || {
+                    isPrerelease: false,
+                    version: ''
+                }
             };
 
         case AppUpdate.ActionTypes.DoNotUpdateApp:

--- a/packages/uhk-web/src/app/store/reducers/auto-update-settings.ts
+++ b/packages/uhk-web/src/app/store/reducers/auto-update-settings.ts
@@ -1,19 +1,18 @@
-import { AutoUpdateSettings } from 'uhk-common';
-
 import * as AutoUpdate from '../actions/auto-update-settings';
 import * as AppUpdate from '../actions/app-update.action';
+import * as App from '../actions/app';
 
-export interface State extends AutoUpdateSettings {
+export interface State {
+    checkForUpdateOnStartUp: boolean;
     checkingForUpdate: boolean;
 }
 
 export const initialState: State = {
     checkForUpdateOnStartUp: false,
-    usePreReleaseUpdate: false,
     checkingForUpdate: false
 };
 
-export function reducer(state = initialState, action: AutoUpdate.Actions | AppUpdate.Actions): State {
+export function reducer(state = initialState, action: AutoUpdate.Actions | AppUpdate.Actions | App.Actions): State {
     switch (action.type) {
         case AutoUpdate.ActionTypes.ToggleCheckForUpdateOnStartup: {
             return {
@@ -22,17 +21,12 @@ export function reducer(state = initialState, action: AutoUpdate.Actions | AppUp
             };
         }
 
-        case AutoUpdate.ActionTypes.TogglePreReleaseFlag: {
-            return {
-                ...state,
-                usePreReleaseUpdate: (action as AutoUpdate.TogglePreReleaseFlagAction).payload
-            };
-        }
+        case App.ActionTypes.LoadApplicationSettingsSuccess: {
+            const { checkForUpdateOnStartUp = true } = (action as App.LoadApplicationSettingsSuccessAction).payload;
 
-        case AutoUpdate.ActionTypes.LoadAutoUpdateSettingSuccess: {
             return {
                 ...state,
-                ...(action as AutoUpdate.LoadAutoUpdateSettingsSuccessAction).payload
+                checkForUpdateOnStartUp
             };
         }
 
@@ -56,10 +50,3 @@ export function reducer(state = initialState, action: AutoUpdate.Actions | AppUp
             return state;
     }
 }
-
-export const getUpdateSettings = (state: State) => ({
-    checkForUpdateOnStartUp: state.checkForUpdateOnStartUp,
-    usePreReleaseUpdate: state.usePreReleaseUpdate
-});
-
-export const checkingForUpdate = (state: State) => state.checkingForUpdate;

--- a/packages/uhk-web/src/renderer/services/electron-datastorage-repository.service.ts
+++ b/packages/uhk-web/src/renderer/services/electron-datastorage-repository.service.ts
@@ -1,6 +1,6 @@
 import * as storage from 'electron-settings';
 
-import { AutoUpdateSettings, UserConfiguration } from 'uhk-common';
+import { ApplicationSettings, UserConfiguration } from 'uhk-common';
 import { DataStorageRepositoryService } from '../../app/services/datastorage-repository.service';
 
 export class ElectronDataStorageRepositoryService implements DataStorageRepositoryService {
@@ -31,11 +31,11 @@ export class ElectronDataStorageRepositoryService implements DataStorageReposito
 
     }
 
-    getAutoUpdateSettings(): AutoUpdateSettings {
-        return ElectronDataStorageRepositoryService.getValue('auto-update-settings');
+    getApplicationSettings(): ApplicationSettings {
+        return ElectronDataStorageRepositoryService.getValue('application-settings');
     }
 
-    saveAutoUpdateSettings(settings: AutoUpdateSettings): void {
-        ElectronDataStorageRepositoryService.saveValue('auto-update-settings', settings);
+    saveApplicationSettings(settings: ApplicationSettings): void {
+        ElectronDataStorageRepositoryService.saveValue('application-settings', settings);
     }
 }


### PR DESCRIPTION
Summary
- renamed AutoUpdateSettings => ApplicationSettings
- deleted the AutoUpdateSettings reading/saving Actions and effects
- added the ApplicationSettings reading/saving Actions and effects
- fix typo
- remove unused imports
- simplified the input properties of AutoUpdateSettings component