### PR TITLE
ci: remove chromium installation on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ shallow_clone: true
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - choco install chromium
   - set CI=true
   - set PATH=%APPDATA%\npm;%PATH%
   - node -v


### PR DESCRIPTION
Chrome 78 installed in the Visual Studio 2017 image