### PR TITLE
fix: firmware upgrade status messages

### DIFF
--- a/packages/uhk-web/package.json
+++ b/packages/uhk-web/package.json
@@ -8,7 +8,7 @@
     "build": "run-p -sn build:*",
     "build:web": "ng build --prod --aot",
     "build:renderer": "ng build --prod --aot --project=uhk-renderer",
-    "server:renderer": "ng build --project=uhk-renderer --watch",
+    "server:renderer": "ng build --project=uhk-renderer --watch --source-map",
     "test-skip": "ng test --watch false",
     "lint": "run-p -snc lint:*",
     "lint:ng": "ng lint",

--- a/packages/uhk-web/src/app/services/app-renderer.service.ts
+++ b/packages/uhk-web/src/app/services/app-renderer.service.ts
@@ -36,8 +36,14 @@ export class AppRendererService {
             this.dispachStoreAction(new ProcessAppStartInfoAction(arg));
         });
 
-        this.ipcRenderer.on('__ELECTRON_LOG_RENDERER__', (event: string, level: string, message: string) => {
-            this.zone.run(() => this.store.dispatch(new ElectronMainLogReceivedAction({level, message})));
+        this.ipcRenderer.on('__ELECTRON_LOG_RENDERER_CONSOLE__', (event: string, { level, data }) => {
+            const message = [];
+
+            for (const item of data) {
+                message.push( typeof item === 'string' ? item : JSON.stringify(item));
+            }
+
+            this.zone.run(() => this.store.dispatch(new ElectronMainLogReceivedAction({ level, message: message.join(' ') })));
         });
     }
 


### PR DESCRIPTION
With electron-logger 3.x (PR #1089) the logging syntax changed. We did not recognize these changes that change at the package upgrade.