### PR TITLE
fix: navigation after udev update

### DIFF
--- a/packages/uhk-agent/src/electron-main.ts
+++ b/packages/uhk-agent/src/electron-main.ts
@@ -108,7 +108,7 @@ function createWindow() {
     deviceService = new DeviceService(logger, win, uhkHidDeviceService, uhkOperations, packagesDir, options);
     appUpdateService = new AppUpdateService(logger, win, app);
     appService = new AppService(logger, win, deviceService, options, uhkHidDeviceService);
-    sudoService = new SudoService(logger, options);
+    sudoService = new SudoService(logger, options, deviceService);
     // and load the index.html of the app.
 
     win.loadURL(url.format({

--- a/packages/uhk-agent/src/services/device.service.ts
+++ b/packages/uhk-agent/src/services/device.service.ts
@@ -264,16 +264,19 @@ export class DeviceService {
         event.sender.send(IpcEvents.device.readConfigSizesReply, JSON.stringify(configSizes));
     }
 
-    private startPollUhkDevice(): void {
+    public startPollUhkDevice(): void {
+        this.logService.info('[DeviceService] start poll UHK Device');
         this._pollerAllowed = true;
     }
 
-    private async stopPollUhkDevice(): Promise<void> {
+    public async stopPollUhkDevice(): Promise<void> {
+        this.logService.info('[DeviceService] stop poll UHK Device');
         return new Promise<void>(async resolve => {
             this._pollerAllowed = false;
 
             while (true) {
                 if (!this._uhkDevicePolling) {
+                    this.logService.info('[DeviceService] stopped poll UHK Device');
                     return resolve();
                 }
 

--- a/packages/uhk-web/src/app/models/index.ts
+++ b/packages/uhk-web/src/app/models/index.ts
@@ -1,3 +1,4 @@
 export * from './last-edited-key';
 export * from './macro-menu-item';
+export * from './navigation-payload';
 export * from './side-menu-page-state';

--- a/packages/uhk-web/src/app/models/navigation-payload.ts
+++ b/packages/uhk-web/src/app/models/navigation-payload.ts
@@ -1,0 +1,6 @@
+import { NavigationExtras } from '@angular/router';
+
+export interface NavigationPayload {
+    commands: Array<string>;
+    extras?: NavigationExtras;
+}

--- a/packages/uhk-web/src/app/store/actions/app.ts
+++ b/packages/uhk-web/src/app/store/actions/app.ts
@@ -2,6 +2,7 @@ import { Action } from '@ngrx/store';
 
 import { ApplicationSettings, AppStartInfo, HardwareConfiguration, Notification } from 'uhk-common';
 import { ElectronLogEntry } from '../../models/xterm-log';
+import { NavigationPayload } from '../../models';
 
 export enum ActionTypes {
     AppBootstrapped = '[app] bootstrapped',
@@ -24,7 +25,8 @@ export enum ActionTypes {
     StartKeypressCapturing = '[app] Start keypress capturing',
     StopKeypressCapturing = '[app] Stop keypress capturing',
     KeyDown = '[app] Key down',
-    KeyUp = '[app] Key up'
+    KeyUp = '[app] Key up',
+    NavigateTo = '[app] NavigateTo'
 }
 
 export class AppBootstrappedAction implements Action {
@@ -142,6 +144,12 @@ export class KeyUpAction implements Action {
     constructor(public payload: KeyboardEvent) {}
 }
 
+export class NavigateTo implements Action {
+    readonly type = ActionTypes.NavigateTo;
+
+    constructor(public payload: NavigationPayload) {}
+}
+
 export type Actions
     = AppStartedAction
     | AppBootstrappedAction
@@ -164,4 +172,5 @@ export type Actions
     | StopKeypressCapturingAction
     | KeyDownAction
     | KeyUpAction
+    | NavigateTo
     ;

--- a/packages/uhk-web/src/app/store/effects/app.ts
+++ b/packages/uhk-web/src/app/store/effects/app.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
 import { Action, Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Observable } from 'rxjs';
@@ -12,6 +13,7 @@ import {
     AppStartedAction,
     DismissUndoNotificationAction,
     LoadApplicationSettingsSuccessAction,
+    NavigateTo,
     OpenUrlInNewWindowAction,
     ProcessAppStartInfoAction,
     SaveApplicationSettingsSuccessAction,
@@ -122,12 +124,25 @@ export class ApplicationEffects {
             })
         );
 
+    @Effect({ dispatch: false }) navigateTo$ = this.actions$
+        .pipe(
+            ofType<NavigateTo>(ActionTypes.NavigateTo),
+            map(action => action.payload),
+            tap(payload => {
+                setTimeout(() => {
+                    this.logService.info('[AppEffects] navigate to', payload);
+                    this.router.navigate(payload.commands, payload.extras);
+                }, 10);
+            })
+        );
+
     constructor(private actions$: Actions,
                 private notifierService: NotifierService,
                 private appUpdateRendererService: AppUpdateRendererService,
                 private appRendererService: AppRendererService,
                 private logService: LogService,
                 private store: Store<AppState>,
-                private dataStorageRepository: DataStorageRepositoryService) {
+                private dataStorageRepository: DataStorageRepositoryService,
+                private router: Router) {
     }
 }

--- a/packages/uhk-web/src/app/store/effects/user-config.ts
+++ b/packages/uhk-web/src/app/store/effects/user-config.ts
@@ -35,7 +35,8 @@ import {
     DismissUndoNotificationAction,
     LoadHardwareConfigurationSuccessAction,
     ShowNotificationAction,
-    UndoLastAction
+    UndoLastAction,
+    NavigateTo
 } from '../actions/app';
 import {
     HardwareModulesLoadedAction,
@@ -167,7 +168,7 @@ export class UserConfigEffects {
                 result.push(new HardwareModulesLoadedAction(data.modules));
 
                 if (newPageDestination) {
-                    this.router.navigate(newPageDestination);
+                    result.push(new NavigateTo({ commands: newPageDestination }));
                 }
 
                 return result;


### PR DESCRIPTION
fix #1128 

The root cause was the UHK Poller ran under the permission setup and broke the user config reading

Tests:
**1.) Update udev file 10/10 success**
  - modify udev file
  - reload udev setting
  - reconnect keyboard
  - start agent
  - Use Update udev file button
  - Agent start success full

**2.) Sep up permissions 10/10 success**
  - delete udev file
  - reload udev setting
  - reconnect keyboard
  - start agent
  - Use Setup Permission button
  - Agent start success full

**3.) Update udev file with unconnected keyboard 5/5 success**
  - unplug agent
  - modify udev file
  - reload udev setting
  - start agent
  - Use Update udev file button
  - UHK Unpluged screen visible
  - plug keyboard 
  - Agent start success full

**4.) Set Permission with unconnected keyboard 5/5 success**
  - unplug agent
  - delete udev file
  - reload udev setting
  - start agent
  - Use Setup Permission button
  - UHK Unpluged screen visible
  - plug keyboard 
  - Agent start success full
