### PR TITLE
fix: positions of the firmware upgrade buttons

### DIFF
--- a/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.html
+++ b/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.html
@@ -16,7 +16,7 @@
                 and Windows XP. Use Windows 10, Windows 8, Linux, or OSX instead.</p>
 
             <p *ngIf="firmwareUpgradeAllowed$ | async">
-                <button class="btn btn-primary"
+                <button class="btn btn-primary action-button"
                         [disabled]="flashFirmwareButtonDisabled$ | async"
                         (click)="onUpdateFirmware()">
                     Flash firmware {{ (getAgentVersionInfo$ | async).firmwareVersion }} (bundled with Agent)

--- a/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.scss
+++ b/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.scss
@@ -9,3 +9,7 @@
 .link-github {
     cursor: pointer;
 }
+
+.action-button {
+    margin-right: 1em;
+}


### PR DESCRIPTION
fixes the following problem
<img width="623" alt="Screenshot 2020-03-19 at 19 36 10" src="https://user-images.githubusercontent.com/496775/77102878-d6482380-6a19-11ea-83d1-8c33e4cf36ee.png">

I think the angular 9 upgrade caused the problem