### PR TITLE
chore: delete the copy:secondary-roles npm script

### DIFF
--- a/packages/uhk-common/package.json
+++ b/packages/uhk-common/package.json
@@ -14,7 +14,6 @@
     "build": "run-s tsc copy:*",
     "tsc": "tsc",
     "copy:scancodes": "copyfiles ./src/config-serializer/config-items/scancodes.json dist",
-    "copy:secondary-roles": "copyfiles ./src/config-serializer/config-items/secondaryRole.json dist",
     "test": "jasmine-ts --config=jasmine.json",
     "coverage": "nyc jasmine-ts --config=jasmine.json",
     "lint": "tslint --project tsconfig.json"


### PR DESCRIPTION
The secondaryRole.json deleted in the #1211 PR