### PR TITLE
chore: use esModuleInterop: true

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1840,6 +1840,18 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/command-line-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.0.0.tgz",
+      "integrity": "sha512-4eOPXyn5DmP64MCMF8ePDvdlvlzt2a+F8ZaVjqmh2yFCpGjc1kI3kGnCFYX9SCsGTjQcWIyVZ86IHCEyjy/MNg==",
+      "dev": true
+    },
+    "@types/command-line-usage": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.1.tgz",
+      "integrity": "sha512-/xUgezxxYePeXhg5S04hUjxG9JZi+rJTs1+4NwpYPfSaS7BeDa6tVJkH6lN9Cb6rl8d24Fi2uX0s0Ngg2JT6gg==",
+      "dev": true
+    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "npm": ">=6.12.0 <7.0.0"
   },
   "devDependencies": {
+    "@types/command-line-args": "5.0.0",
+    "@types/command-line-usage": "5.0.1",
     "@types/decompress": "4.2.3",
     "@types/electron-devtools-installer": "2.0.2",
     "@types/electron-settings": "3.0.0",

--- a/packages/uhk-agent/src/custom_types/command-line-args.d.ts
+++ b/packages/uhk-agent/src/custom_types/command-line-args.d.ts
@@ -1,1 +1,0 @@
-declare module 'command-line-args';

--- a/packages/uhk-agent/src/custom_types/command-line-usage.d.ts
+++ b/packages/uhk-agent/src/custom_types/command-line-usage.d.ts
@@ -1,1 +1,0 @@
-declare module 'command-line-usage';

--- a/packages/uhk-agent/src/custom_types/decompress.d.ts
+++ b/packages/uhk-agent/src/custom_types/decompress.d.ts
@@ -1,1 +1,0 @@
-declare module 'decompress';

--- a/packages/uhk-agent/src/services/app-update.service.ts
+++ b/packages/uhk-agent/src/services/app-update.service.ts
@@ -1,9 +1,9 @@
 import { ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { UpdateInfo, ProgressInfo } from 'builder-util-runtime';
-import * as settings from 'electron-settings';
+import settings from 'electron-settings';
 import * as isDev from 'electron-is-dev';
-import * as storage from 'electron-settings';
+import storage from 'electron-settings';
 
 import { ApplicationSettings, IpcEvents, LogService } from 'uhk-common';
 import { MainServiceBase } from './main-service-base';

--- a/packages/uhk-agent/src/util/command-line.ts
+++ b/packages/uhk-agent/src/util/command-line.ts
@@ -1,11 +1,8 @@
-/// <reference path="../custom_types/command-line-args.d.ts"/>
-/// <reference path="../custom_types/command-line-usage.d.ts"/>
-
-import * as commandLineArgs from 'command-line-args';
-import * as commandLineUsage from 'command-line-usage';
+import commandLineArgs from 'command-line-args';
+import commandLineUsage from 'command-line-usage';
 import { CommandLineArgs } from 'uhk-common';
 
-const optionDefinitions = [
+const optionDefinitions: commandLineArgs.OptionDefinition[] = [
     { name: 'modules', type: Boolean },
     { name: 'help', type: Boolean },
     { name: 'preserve-udev-rules', type: Boolean },
@@ -13,9 +10,9 @@ const optionDefinitions = [
     { name: 'usb-driver', type: String }
 ];
 
-export const options: CommandLineArgs = commandLineArgs(optionDefinitions, { partial: true });
+export const options: CommandLineArgs = commandLineArgs(optionDefinitions, { partial: true }) as CommandLineArgs;
 
-const sections = [
+const sections: commandLineUsage.Section[] = [
     {
         header: 'UHK Agent',
         content: 'Ultimate Hacking Keyboard configurator'

--- a/packages/uhk-agent/src/util/save-extract-firmware.ts
+++ b/packages/uhk-agent/src/util/save-extract-firmware.ts
@@ -1,17 +1,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { dirSync } from 'tmp';
-import * as decompress from 'decompress';
-import * as decompressTarbz from 'decompress-tarbz2';
-import * as decompressTargz from 'decompress-targz';
-import { extname } from 'path';
+import decompress from 'decompress';
+import decompressTarbz from 'decompress-tarbz2';
+import decompressTargz from 'decompress-targz';
 import { UploadFileData } from 'uhk-common';
 
 import { TmpFirmware } from '../models/tmp-firmware';
 
 export async function saveTmpFirmware(fileData: UploadFileData): Promise<TmpFirmware> {
     const tmpDirectory = dirSync();
-    const extension = extname(fileData.filename);
+    const extension = path.extname(fileData.filename);
     const zipFilePath = path.join(tmpDirectory.name, `firmware${extension}`);
 
     await writeDataToFile(fileData.data, zipFilePath);

--- a/packages/uhk-agent/src/util/window.ts
+++ b/packages/uhk-agent/src/util/window.ts
@@ -1,5 +1,5 @@
 import * as electron from 'electron';
-import * as settings from 'electron-settings';
+import settings from 'electron-settings';
 
 import { logger } from '../services/logger.service';
 import { WindowState } from '../models/window-state';

--- a/packages/uhk-common/src/util/create-md5-hash.ts
+++ b/packages/uhk-common/src/util/create-md5-hash.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer/';
-import * as md5 from 'md5';
+import md5 from 'md5';
 
 export function createMd5Hash(buffer: Buffer): string {
     return md5(buffer);

--- a/packages/uhk-common/src/util/user-configuration-history-helpers.ts
+++ b/packages/uhk-common/src/util/user-configuration-history-helpers.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 
 export const FILENAME_DATE_FORMAT = 'YYYYMMDD-HHmmss';
 export const DISPLAY_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,10 @@
     "declaration": true,
     "module": "commonjs",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2016",
+    "target": "ES2016",
     "importHelpers": true
   }
 }


### PR DESCRIPTION
The new es6 module packages are not compatible with the old TypeScript config setup, so uses the `esModuleInterop: true`.

Summary of the modifications:
- Uses official typings of the following packages
  - command-line-args
  - command-line-usage
  - decompress
- Change the module import syntax of the modules that support default exports.

Following functions tested:
- Setup udev permission on Linux
- Modify user configuration and save to keyboard
- Restore default configuration
- Export user config
- Import user config
- Restore user config from the history
- Save/load application settings
  