### PR TITLE
chore: upgrade electron-log => 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5564,9 +5564,9 @@
       }
     },
     "electron-log": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-3.0.8.tgz",
-      "integrity": "sha512-B9+eJ8z3UbDnWEz+G33SIJvEDeKLznHEV4sCu6bR31KuOdp3dYN046QBWbLNsvKU+lzFI6eOi+xNCpNHZvatiw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.2.0.tgz",
+      "integrity": "sha512-Yy1X8iZEzoBA8pu5b7YU07dRHi1GPM9C5jLEOn87Uqtdc9rbe6KbvvQ/AAAtGvn4/GC3azRW/eeiSI4ZF+Hm2A==",
       "dev": true
     },
     "electron-notarize": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "electron-builder": "22.5.1",
     "electron-debug": "1.5.0",
     "electron-devtools-installer": "2.2.3",
-    "electron-log": "3.0.8",
+    "electron-log": "4.2.0",
     "electron-notarize": "0.3.0",
     "electron-rebuild": "1.10.0",
     "electron-settings": "3.1.4",

--- a/packages/uhk-agent/src/services/logger.service.ts
+++ b/packages/uhk-agent/src/services/logger.service.ts
@@ -1,6 +1,10 @@
+import * as path from 'path';
 import * as log from 'electron-log';
-log.transports.file.level = 'debug';
+
 log.transports.console.level = 'debug';
-log.transports.rendererConsole.level = 'debug';
+log.transports.file.level = 'debug';
+log.transports.file.resolvePath = variables => {
+    return path.join(variables.libraryDefaultDir, 'uhk-agent.log');
+};
 
 export const logger = log;

--- a/packages/uhk-web/src/renderer/services/electron-log.service.ts
+++ b/packages/uhk-web/src/renderer/services/electron-log.service.ts
@@ -1,7 +1,13 @@
+import * as path from 'path';
 import { Injectable } from '@angular/core';
 import * as log from 'electron-log';
 import * as util from 'util';
 import { LogRegExps, LogService } from 'uhk-common';
+
+log.transports.file.level = 'debug';
+log.transports.file.resolvePath = variables => {
+    return path.join(variables.libraryDefaultDir, 'uhk-agent.log');
+};
 
 // https://github.com/megahertz/electron-log/issues/44
 // console.debug starting with Chromium 58 this method is a no-op on Chromium browsers.
@@ -25,9 +31,9 @@ if (console.debug) {
  * This service use the electron-log package to write log in file.
  * The logger usable in main and renderer process.
  * The location of the log files:
- * - on Linux: ~/.config/<app name>/log.log
- * - on OS X: ~/Library/Logs/<app name>/log.log
- * - on Windows: %USERPROFILE%\AppData\Roaming\<app name>\log.log
+ * - on Linux: ~/.config/<app name>/uhk-agent.log
+ * - on OS X: ~/Library/Logs/<app name>/uhk-agent.log
+ * - on Windows: %USERPROFILE%\AppData\Roaming\<app name>\uhk-agent.log
  * The app name: UHK Agent. The up to date value in the scripts/release.js file.
  */
 @Injectable()


### PR DESCRIPTION
Change the log file name from `log.log` => `uhk-agent.log`.
The log folder does not change.