### PR TITLE
feat: reenumerate-and-exit commandline argument

### DIFF
--- a/packages/uhk-agent/src/util/command-line.ts
+++ b/packages/uhk-agent/src/util/command-line.ts
@@ -7,6 +7,7 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
     { name: 'modules', type: Boolean },
     { name: 'help', type: Boolean },
     { name: 'preserve-udev-rules', type: Boolean },
+    { name: 'reenumerate-and-exit', type: String },
     { name: 'spe', type: Boolean }, // simulate privilege escalation error
     { name: 'usb-driver', type: String }
 ];
@@ -33,6 +34,13 @@ const sections: commandLineUsage.Section[] = [
             {
                 name: 'preserve-udev-rules',
                 description: 'Don\'t force udev rule update'
+            },
+            {
+                name: 'reenumerate-and-exit',
+                description: 'Reenumerate as the bootloader or BusPal, wait for the specified seconds and exit. ' +
+                    'May make Windows install the relevant USB drivers.' +
+                    'Please provide timeout in millisecond.',
+                typeLabel: '(bootloader|buspal),timeout'
             },
             {
                 name: 'spe',

--- a/packages/uhk-agent/src/util/index.ts
+++ b/packages/uhk-agent/src/util/index.ts
@@ -6,6 +6,7 @@ export * from './get-updater-logger';
 export * from './get-user-config-from-history-async';
 export * from './get-user-config-history-dir-async';
 export * from './load-user-config-history-async';
+export * from './reenumerate-and-exit';
 export * from './sanity-check-firmware';
 export * from './save-extract-firmware';
 export * from './save-user-config-history-async';

--- a/packages/uhk-agent/src/util/reenumerate-and-exit.ts
+++ b/packages/uhk-agent/src/util/reenumerate-and-exit.ts
@@ -1,0 +1,74 @@
+import { UhkHidDevice, EnumerationModes } from 'uhk-usb';
+import { CommandLineArgs } from 'uhk-common';
+
+import { ElectronLogService } from '../services/logger.service';
+import { devices } from 'node-hid';
+
+export interface ReenumerateAndExitOptions {
+    logger: ElectronLogService;
+    uhkHidDevice: UhkHidDevice;
+    commandLineArgs: CommandLineArgs;
+}
+
+export async function reenumerateAndExit(options: ReenumerateAndExitOptions): Promise<void> {
+    const arg = options.commandLineArgs['reenumerate-and-exit'];
+    options.logger.misc(`[reenumerateAndExit] Command line argument: ${arg}`);
+
+    options.logger.misc('[reenumerateAndExit] list available devices');
+    options.uhkHidDevice.listAvailableDevices(devices());
+
+    const startTime = new Date();
+    const reenumerationOption = parseReenumerateAndExitArg(arg);
+
+    await options.uhkHidDevice.reenumerate(reenumerationOption.mode, reenumerationOption.timeout);
+
+    options.logger.misc('[reenumerateAndExit] Reenumeration success');
+    options.logger.misc('[reenumerateAndExit] Monitoring device list changes');
+
+    const waitTime = reenumerationOption.timeout + 10000;
+
+    while (new Date().getTime() - startTime.getTime() < waitTime) {
+        options.uhkHidDevice.listAvailableDevices(devices());
+    }
+}
+
+interface ReenumerationOption {
+    timeout: number;
+    mode: EnumerationModes;
+}
+
+function parseReenumerateAndExitArg(arg: string): ReenumerationOption {
+    const split = arg.split(',');
+
+    if (split.length !== 2) {
+        throw new Error('Argument must be in "(bootloader|buspal),timeout" format');
+    }
+
+    return {
+        mode: parseEnumerationMode(split[0]),
+        timeout: parseEnumerationTimeout(split[1])
+    };
+}
+
+function parseEnumerationMode(mode: string): EnumerationModes {
+    switch (mode) {
+        case 'bootloader':
+            return EnumerationModes.Bootloader;
+
+        case 'buspal':
+            return EnumerationModes.Buspal;
+
+        default:
+            throw new Error(`Unknown enumeration mode: ${mode}`);
+    }
+}
+
+function parseEnumerationTimeout(timeout: string): number {
+    const numValue = Number.parseInt(timeout);
+
+    if (Number.isNaN(numValue)) {
+        throw new Error(`Invalid timeout value ${timeout}`);
+    }
+
+    return numValue;
+}

--- a/packages/uhk-common/src/models/command-line-args.ts
+++ b/packages/uhk-common/src/models/command-line-args.ts
@@ -16,6 +16,11 @@ export interface CommandLineArgs {
      */
     'preserve-udev-rules'?: boolean;
     /**
+     * Reenumerate as the bootloader or BusPal, wait for the specified seconds and exit.
+     * May make Windows install the relevant USB drivers.
+     */
+    'reenumerate-and-exit'?: string;
+    /**
      * simulate privilege escalation error
      */
     spe?: boolean;


### PR DESCRIPTION
test commands
`$ npm run electron -- -- -- --reenumerate-and-exit=buspal,10000`
`$ npm run electron -- -- -- --reenumerate-and-exit=bootloader,10000`