### PR TITLE
fix(web): auto-grow-input non edit mode width calculation

### DIFF
--- a/packages/uhk-web/src/app/components/auto-grow-input/auto-grow-input.component.ts
+++ b/packages/uhk-web/src/app/components/auto-grow-input/auto-grow-input.component.ts
@@ -144,7 +144,7 @@ export class AutoGrowInputComponent implements ControlValueAccessor, AfterViewIn
         }
         maxWidth = Math.max(this.minWidth, maxWidth); // Clamp to ensure usable width
 
-        let textWidth = util.getContentWidth(window.getComputedStyle(htmlInput), text);
+        let textWidth = util.getContentWidth(window.getComputedStyle(htmlInput), text) + 1;
 
         if (this._inEditMode) {
             textWidth += util.getContentWidth(window.getComputedStyle(htmlInput), 'W') * 1.1;


### PR DESCRIPTION
The new Chrome 87.0.4280.88 changed the text length calculation. This version will be used in the newer version of electrons so I though I implement the fix now.

The fix: add an extra pixel to the calculated length.

Before the fix
<img width="224" alt="Screenshot 2021-01-05 at 21 00 42" src="https://user-images.githubusercontent.com/496775/103693631-e970b380-4f99-11eb-8a0c-c23ac46b2994.png">

After:
<img width="228" alt="Screenshot 2021-01-05 at 21 02 27" src="https://user-images.githubusercontent.com/496775/103693611-de1d8800-4f99-11eb-9156-2599a1d2191b.png">
