### PR TITLE
feat: when a macro is deleted, navigate to the below macro

### DIFF
--- a/packages/uhk-common/src/config-serializer/config-items/user-configuration.ts
+++ b/packages/uhk-common/src/config-serializer/config-items/user-configuration.ts
@@ -77,6 +77,14 @@ export class UserConfiguration implements MouseSpeedConfiguration {
         this.setDefaultDeviceName();
     }
 
+    clone(): UserConfiguration {
+       const userConfig = Object.assign(new UserConfiguration(), this);
+       userConfig.keymaps = userConfig.keymaps.map(keymap => new Keymap(keymap));
+       userConfig.macros = userConfig.macros.map(macro => new Macro(macro));
+
+       return userConfig;
+    }
+
     fromJsonObject(jsonObject: any): UserConfiguration {
         this.userConfigMajorVersion = jsonObject.userConfigMajorVersion;
         this.userConfigMinorVersion = jsonObject.userConfigMinorVersion;

--- a/packages/uhk-web/src/app/models/undo-user-config-data.ts
+++ b/packages/uhk-web/src/app/models/undo-user-config-data.ts
@@ -1,4 +1,6 @@
+import { UserConfiguration } from 'uhk-common';
+
 export interface UndoUserConfigData {
     path: string;
-    config: string;
+    config: UserConfiguration;
 }

--- a/packages/uhk-web/src/app/store/effects/macro.ts
+++ b/packages/uhk-web/src/app/store/effects/macro.ts
@@ -8,7 +8,7 @@ import { map, pairwise, tap, withLatestFrom } from 'rxjs/operators';
 import { Macro } from 'uhk-common';
 import * as Keymaps from '../actions/keymap';
 import * as Macros from '../actions/macro';
-import { AppState, getMacros } from '..';
+import { AppState, getSelectedMacroIdAfterRemove, getMacros } from '..';
 import { findNewItem } from '../../util';
 
 @Injectable()
@@ -18,14 +18,14 @@ export class MacroEffects {
         .pipe(
             ofType<Macros.RemoveMacroAction>(Macros.ActionTypes.Remove),
             tap(action => this.store.dispatch(new Keymaps.CheckMacroAction(action.payload))),
-            withLatestFrom(this.store.select(getMacros)),
-            map(([action, macros]) => macros),
-            tap(macros => {
-                    if (macros.length === 0) {
-                        return this.router.navigate(['/macro']);
+            withLatestFrom(this.store.select(getSelectedMacroIdAfterRemove)),
+            map(([, newMacroId]) => newMacroId),
+            tap(newMacroId => {
+                    if (newMacroId) {
+                        return this.router.navigate(['/macro', newMacroId]);
                     }
 
-                    return this.router.navigate(['/macro', macros[0].id]);
+                    return this.router.navigate(['/macro']);
                 }
             )
         );

--- a/packages/uhk-web/src/app/store/effects/user-config.ts
+++ b/packages/uhk-web/src/app/store/effects/user-config.ts
@@ -77,7 +77,7 @@ export class UserConfigEffects {
                     const pathPrefix = action.type === Keymaps.ActionTypes.Remove ? 'keymap' : 'macro';
                     const payload: UndoUserConfigData = {
                         path: `/${pathPrefix}/${(action as Keymaps.RemoveKeymapAction | Macros.RemoveMacroAction).payload}`,
-                        config: prevUserConfiguration.toJsonObject()
+                        config: prevUserConfiguration.clone()
                     };
 
                     return [
@@ -107,11 +107,10 @@ export class UserConfigEffects {
             ofType<UndoLastAction>(Keymaps.ActionTypes.UndoLastAction),
             map(action => action.payload),
             mergeMap((payload: UndoUserConfigData) => {
-                const config = new UserConfiguration().fromJsonObject(payload.config);
-                this.dataStorageRepository.saveConfig(config);
+                this.dataStorageRepository.saveConfig(payload.config);
                 this.router.navigate([payload.path]);
 
-                return [new LoadUserConfigSuccessAction(config)];
+                return [new LoadUserConfigSuccessAction(payload.config)];
             })
         );
 

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -81,6 +81,7 @@ export const isKeymapDeletable = createSelector(userConfigState, fromUserConfig.
 export const hasMacro = createSelector(userConfigState, fromUserConfig.hasMacro);
 export const getMacroMap = createSelector(userConfigState, fromUserConfig.getMacroMap);
 export const lastEditedKey = createSelector(userConfigState, fromUserConfig.lastEditedKey);
+export const getSelectedMacroIdAfterRemove = createSelector(userConfigState, fromUserConfig.getSelectedMacroIdAfterRemove);
 export const getKeymapOptions = createSelector(getKeymaps, getSelectedKeymap, (keymaps, selectedKeymap): SelectOptionData[] => {
     return keymaps.map(keymap => {
         return {


### PR DESCRIPTION
close: #1454

Logic
- when a macro deleted it is not last macro than navigate to the below macro
- when a macro deleted it is last macro than navigate to the above macro
- when the macro deleted and after the user undo the deletion than navigate to the restored macro