### PR TITLE
Feature: Handle reorder of USB mgmt interface 

### DIFF
--- a/packages/uhk-agent/src/util/reenumerate-and-exit.ts
+++ b/packages/uhk-agent/src/util/reenumerate-and-exit.ts
@@ -20,6 +20,7 @@ export async function reenumerateAndExit(options: ReenumerateAndExitOptions): Pr
     options.logger.misc(`[reenumerateAndExit] Command line argument: ${arg}`);
 
     options.logger.misc('[reenumerateAndExit] list available devices');
+    // TODO: pass vendor id ????
     options.uhkHidDevice.listAvailableDevices(devices());
 
     const startTime = new Date();
@@ -39,6 +40,7 @@ export async function reenumerateAndExit(options: ReenumerateAndExitOptions): Pr
     const waitTime = reenumerationOption.timeout + 10000;
 
     while (new Date().getTime() - startTime.getTime() < waitTime) {
+        // TODO: pass vendor id ????
         options.uhkHidDevice.listAvailableDevices(devices());
     }
 }

--- a/packages/uhk-common/src/models/device-connection-state.ts
+++ b/packages/uhk-common/src/models/device-connection-state.ts
@@ -10,7 +10,7 @@ export interface DeviceConnectionState {
      * True if more then 1 UHK device connected.
      */
     multiDevice: boolean;
-    zeroInterfaceAvailable: boolean;
+    mgmtInterfaceAvailable: boolean;
     halvesInfo: HalvesInfo;
     hardwareModules?: HardwareModules;
 }

--- a/packages/uhk-common/src/models/uhk-products.ts
+++ b/packages/uhk-common/src/models/uhk-products.ts
@@ -12,6 +12,10 @@ export interface UhkDeviceProduct {
     // USB bootloader product ID
     bootloaderPid: number;
     buspalPid: number;
+    // Management interface HID Usage Page
+    usagePage: number;
+    // Management interface HID Usage
+    usage: number;
 }
 
 export const UHK_60_DEVICE: UhkDeviceProduct = {
@@ -20,7 +24,9 @@ export const UHK_60_DEVICE: UhkDeviceProduct = {
     vendorId: 0x1D50,
     keyboardPid: 0x6122,
     bootloaderPid: 0x6120,
-    buspalPid: 0x6121
+    buspalPid: 0x6121,
+    usagePage: 0xFF00,
+    usage: 0x01
 };
 
 export const UHK_60_V2_DEVICE: UhkDeviceProduct = {
@@ -29,7 +35,9 @@ export const UHK_60_V2_DEVICE: UhkDeviceProduct = {
     vendorId: 0x1D50,
     keyboardPid: 0x6124,
     bootloaderPid: 0x6123,
-    buspalPid: 0x6121
+    buspalPid: 0x6121,
+    usagePage: 0xFF00,
+    usage: 0x01
 };
 
 export const UHK_DEVICES: Array<UhkDeviceProduct> = [

--- a/packages/uhk-usb/src/uhk-hid-device.ts
+++ b/packages/uhk-usb/src/uhk-hid-device.ts
@@ -30,7 +30,7 @@ import {
     getTransferData,
     isBootloader,
     getUhkDevice,
-    isUhkZeroInterface,
+    isUhkMgmtInterface,
     retry,
     snooze
 } from './util';
@@ -75,10 +75,11 @@ export class UhkHidDevice {
             }
 
             this.logService.misc('[UhkHidDevice] Devices before checking permission:');
+            // TODO: pass vendor ID ???
             const devs = devices();
             this.logDevices(devs);
 
-            const dev = devs.find((x: Device) => isUhkZeroInterface(x) || isBootloader(x));
+            const dev = devs.find((x: Device) => isUhkMgmtInterface(x) || isBootloader(x));
 
             if (!dev) {
                 return true;
@@ -102,10 +103,11 @@ export class UhkHidDevice {
      * @returns {DeviceConnectionState}
      */
     public async getDeviceConnectionStateAsync(): Promise<DeviceConnectionState> {
+        // TODO: Pass vendorid ???
         const devs = devices();
         const result: DeviceConnectionState = {
             bootloaderActive: false,
-            zeroInterfaceAvailable: false,
+            mgmtInterfaceAvailable: false,
             hasPermission: this.hasPermission(),
             halvesInfo: {
                 areHalvesMerged: true,
@@ -126,14 +128,14 @@ export class UhkHidDevice {
                 result.connectedDevice = getUhkDevice(dev);
             }
 
-            if (isUhkZeroInterface(dev)) {
-                result.zeroInterfaceAvailable = true;
+            if (isUhkMgmtInterface(dev)) {
+                result.mgmtInterfaceAvailable = true;
             } else if (isBootloader(dev)) {
                 result.bootloaderActive = true;
             }
         }
 
-        if (result.connectedDevice && result.hasPermission && result.zeroInterfaceAvailable) {
+        if (result.connectedDevice && result.hasPermission && result.mgmtInterfaceAvailable) {
             result.halvesInfo = await this.getHalvesStates();
         } else if (!result.connectedDevice) {
             this._device = undefined;
@@ -216,6 +218,7 @@ export class UhkHidDevice {
         let jumped = false;
 
         while (new Date().getTime() - startTime.getTime() < waitTimeout) {
+            // TODO: pass vendor id ????
             const devs = devices();
 
             const inBootloaderMode = devs.some((x: Device) =>
@@ -374,10 +377,11 @@ export class UhkHidDevice {
      */
     private connectToDevice({ errorLogLevel = 'error' }: GetDeviceOptions = {}): HID {
         try {
+            // TODO: pass vendorid ???
             const devs = devices();
             this.listAvailableDevices(devs);
 
-            const dev = devs.find(isUhkZeroInterface);
+            const dev = devs.find(isUhkMgmtInterface);
 
             if (!dev) {
                 this.logService.misc('[UhkHidDevice] UHK Device not found:');

--- a/packages/uhk-usb/src/utils/get-current-uhk-device-product-by-bootloader-id.ts
+++ b/packages/uhk-usb/src/utils/get-current-uhk-device-product-by-bootloader-id.ts
@@ -6,6 +6,7 @@ import { validateConnectedDevices } from './validate-connected-devices';
 export function getCurrentUhkDeviceProductByBootloaderId(): UhkDeviceProduct | undefined {
     validateConnectedDevices();
 
+    // TODO: pass vendor id ????
     const hidDevices = devices();
 
     for (const hidDevice of hidDevices) {

--- a/packages/uhk-usb/src/utils/get-current-uhk-device-product.ts
+++ b/packages/uhk-usb/src/utils/get-current-uhk-device-product.ts
@@ -6,6 +6,7 @@ import { validateConnectedDevices } from './validate-connected-devices';
 export function getCurrentUhkDeviceProduct(): UhkDeviceProduct | undefined {
     validateConnectedDevices();
 
+    // TODO: pass vendor id ????
     const hidDevices = devices();
 
     for (const hidDevice of hidDevices) {

--- a/packages/uhk-usb/src/utils/get-number-of-connected-devices.ts
+++ b/packages/uhk-usb/src/utils/get-number-of-connected-devices.ts
@@ -1,9 +1,10 @@
 import { devices } from 'node-hid';
 
-import { isBootloader, isUhkZeroInterface } from '../util';
+import { isBootloader, isUhkMgmtInterface } from '../util';
 
 export function getNumberOfConnectedDevices(): number {
+    // TODO: pass vendor id ????
     return devices()
-        .filter(dev => isUhkZeroInterface(dev) || isBootloader(dev))
+        .filter(dev => isUhkMgmtInterface(dev) || isBootloader(dev))
         .length;
 }

--- a/packages/uhk-web/src/app/store/effects/device.ts
+++ b/packages/uhk-web/src/app/store/effects/device.ts
@@ -74,7 +74,7 @@ export class DeviceEffects {
                     return this.router.navigate(['/recovery-device']);
                 }
 
-                if (state.connectedDevice && state.zeroInterfaceAvailable) {
+                if (state.connectedDevice && state.mgmtInterfaceAvailable) {
                     const allowDefaultNavigation = [
                         '/detection',
                         '/privilege',
@@ -96,14 +96,14 @@ export class DeviceEffects {
 
                 return prevConnected === currConnected &&
                     prevAction.payload.hasPermission === currAction.payload.hasPermission &&
-                    prevAction.payload.zeroInterfaceAvailable === currAction.payload.zeroInterfaceAvailable;
+                    prevAction.payload.mgmtInterfaceAvailable === currAction.payload.mgmtInterfaceAvailable;
             }),
             mergeMap(([action, route, connected]) => {
                 const payload = action.payload;
 
                 if (connected
                     && payload.hasPermission
-                    && payload.zeroInterfaceAvailable) {
+                    && payload.mgmtInterfaceAvailable) {
 
                     return [
                         new ReadConfigSizesAction(),

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -126,7 +126,7 @@ export const deviceConnected = createSelector(
         }
 
         if (app.platform === 'linux') {
-            return device.connectedDevice && (device.zeroInterfaceAvailable || device.updatingFirmware);
+            return device.connectedDevice && (device.mgmtInterfaceAvailable || device.updatingFirmware);
         }
 
         return !!device.connectedDevice;

--- a/packages/uhk-web/src/app/store/reducers/device.ts
+++ b/packages/uhk-web/src/app/store/reducers/device.ts
@@ -15,7 +15,7 @@ export interface State {
     hasPermission: boolean;
     bootloaderActive: boolean;
     multiDevice: boolean;
-    zeroInterfaceAvailable: boolean;
+    mgmtInterfaceAvailable: boolean;
     saveToKeyboard: ProgressButtonState;
     savingToKeyboard: boolean;
     updatingFirmware: boolean;
@@ -36,7 +36,7 @@ export const initialState: State = {
     hasPermission: true,
     bootloaderActive: false,
     multiDevice: false,
-    zeroInterfaceAvailable: true,
+    mgmtInterfaceAvailable: true,
     saveToKeyboard: initProgressButtonState,
     savingToKeyboard: false,
     updatingFirmware: false,
@@ -64,7 +64,7 @@ export function reducer(state = initialState, action: Action): State {
                 ...state,
                 connectedDevice: data.connectedDevice,
                 hasPermission: data.hasPermission,
-                zeroInterfaceAvailable: data.zeroInterfaceAvailable,
+                mgmtInterfaceAvailable: data.mgmtInterfaceAvailable,
                 bootloaderActive: data.bootloaderActive,
                 halvesInfo: data.halvesInfo,
                 modules: data.hardwareModules,
@@ -247,7 +247,7 @@ export const updatingFirmware = (state: State) => state.updatingFirmware;
 export const isDeviceConnected = (state: State) => state.connectedDevice || state.updatingFirmware;
 export const hasDevicePermission = (state: State) => state.hasPermission;
 export const getMissingDeviceState = (state: State): MissingDeviceState => {
-    if (state.connectedDevice && !state.zeroInterfaceAvailable) {
+    if (state.connectedDevice && !state.mgmtInterfaceAvailable) {
         return {
             header: 'Cannot find your UHK',
             subtitle: 'Please reconnect it!'


### PR DESCRIPTION
Handles reordering USB Management interface.  Will try to detect based on HID Usage if available.   On some Linux setups, usage may not be available, then defaults to probing interfaces, since we know that this is a UHK keyboard.

This needs testing before merge. Please Test and report!