### PR TITLE
fix: connection state query at application start

### DIFF
--- a/packages/uhk-agent/src/electron-main.ts
+++ b/packages/uhk-agent/src/electron-main.ts
@@ -93,9 +93,9 @@ function createWindow() {
     }
 
     setMenu(win);
-    deviceService = new DeviceService(logger, win, uhkHidDeviceService, uhkOperations, packagesDir, options);
+    deviceService = new DeviceService(logger, win, uhkHidDeviceService, uhkOperations, packagesDir);
     appUpdateService = new AppUpdateService(logger, win, app);
-    appService = new AppService(logger, win, deviceService, options, uhkHidDeviceService, packagesDir);
+    appService = new AppService(logger, win, deviceService, options, packagesDir);
     sudoService = new SudoService(logger, options, deviceService, packagesDir);
 // and load the index.html of the app.
 

--- a/packages/uhk-agent/src/services/app.service.ts
+++ b/packages/uhk-agent/src/services/app.service.ts
@@ -1,5 +1,4 @@
 import { ipcMain, shell } from 'electron';
-import { UhkHidDevice } from 'uhk-usb';
 import * as os from 'os';
 
 import { AppStartInfo, CommandLineArgs, IpcEvents, LogService } from 'uhk-common';
@@ -12,7 +11,6 @@ export class AppService extends MainServiceBase {
                 protected win: Electron.BrowserWindow,
                 private deviceService: DeviceService,
                 private options: CommandLineArgs,
-                private uhkHidDeviceService: UhkHidDevice,
                 private rootDir: string) {
         super(logService, win);
 
@@ -23,29 +21,23 @@ export class AppService extends MainServiceBase {
     }
 
     private async handleAppStartInfo(event: Electron.IpcMainEvent) {
-        this.logService.misc('[AppService] getAppStartInfo');
-        const deviceConnectionState = await this.uhkHidDeviceService.getDeviceConnectionStateAsync();
-        if (deviceConnectionState.hasPermission && deviceConnectionState.connectedDevice) {
-            deviceConnectionState.hardwareModules = await this.deviceService.getHardwareModules(false);
-        } else {
-            deviceConnectionState.hardwareModules = {
-                moduleInfos: [],
-                rightModuleInfo: {}
-            };
-        }
+        try {
+            this.logService.misc('[AppService] getAppStartInfo');
 
-        const response: AppStartInfo = {
-            deviceConnectionState,
-            commandLineArgs: {
-                modules: this.options.modules || false,
-                log: this.options.log
-            },
-            platform: process.platform as string,
-            osVersion: os.release(),
-            udevFileContent: await getUdevFileContentAsync(this.rootDir)
-        };
-        this.logService.misc('[AppService] getAppStartInfo response:', response);
-        return event.sender.send(IpcEvents.app.getAppStartInfoReply, response);
+            const response: AppStartInfo = {
+                commandLineArgs: {
+                    modules: this.options.modules || false,
+                    log: this.options.log
+                },
+                platform: process.platform as string,
+                osVersion: os.release(),
+                udevFileContent: await getUdevFileContentAsync(this.rootDir)
+            };
+            this.logService.misc('[AppService] getAppStartInfo response:', response);
+            return event.sender.send(IpcEvents.app.getAppStartInfoReply, response);
+        } catch (error) {
+            this.logService.misc('[AppService] getAppStartInfo failed:', error);
+        }
     }
 
     private exit() {

--- a/packages/uhk-agent/src/services/device.service.ts
+++ b/packages/uhk-agent/src/services/device.service.ts
@@ -1,7 +1,6 @@
 import { ipcMain } from 'electron';
 import { isEqual } from 'lodash';
 import {
-    CommandLineArgs,
     ConfigurationReply,
     DeviceConnectionState,
     findUhkModuleById,
@@ -63,9 +62,8 @@ export class DeviceService {
                 private win: Electron.BrowserWindow,
                 private device: UhkHidDevice,
                 private operations: UhkOperations,
-                private rootDir: string,
-                private options: CommandLineArgs) {
-        this.startPollUhkDevice();
+                private rootDir: string
+    ) {
         this.uhkDevicePoller()
             .catch(error => {
                 this.logService.error('[DeviceService] UHK Device poller error', error);

--- a/packages/uhk-common/src/models/app-start-info.ts
+++ b/packages/uhk-common/src/models/app-start-info.ts
@@ -1,9 +1,7 @@
 import { CommandLineArgs } from './command-line-args';
-import { DeviceConnectionState } from './device-connection-state';
 
 export interface AppStartInfo {
     commandLineArgs: CommandLineArgs;
-    deviceConnectionState: DeviceConnectionState;
     platform: string;
     osVersion: string;
     udevFileContent: string;

--- a/packages/uhk-web/src/app/app.routes.ts
+++ b/packages/uhk-web/src/app/app.routes.ts
@@ -33,7 +33,8 @@ const appRoutes: Routes = [
     },
     {
         path: 'loading',
-        component: LoadingDevicePageComponent
+        component: LoadingDevicePageComponent,
+        canActivate: [UhkDeviceDisconnectedGuard]
     },
     {
         path: 'multi-device',

--- a/packages/uhk-web/src/app/store/effects/app.ts
+++ b/packages/uhk-web/src/app/store/effects/app.ts
@@ -24,7 +24,7 @@ import {
 import { ActionTypes as UpdateActionTypes } from '../actions/auto-update-settings';
 import { AppRendererService } from '../../services/app-renderer.service';
 import { AppUpdateRendererService } from '../../services/app-update-renderer.service';
-import { ActionTypes as DeviceActionTypes, ConnectionStateChangedAction } from '../actions/device';
+import { ActionTypes as DeviceActionTypes, StartConnectionPollerAction } from '../actions/device';
 import { AppState, getApplicationSettings, runningInElectron } from '../index';
 import { DataStorageRepositoryService } from '../../services/datastorage-repository.service';
 
@@ -86,7 +86,7 @@ export class ApplicationEffects {
                 this.logService.misc('[AppEffect][processStartInfo] payload:', appInfo);
                 return [
                     new ApplyAppStartInfoAction(appInfo),
-                    new ConnectionStateChangedAction(appInfo.deviceConnectionState)
+                    new StartConnectionPollerAction()
                 ];
             })
         );


### PR DESCRIPTION
story: #1492

The application start event and the device service initialisation had race condition if the device connection state query is slow - mainly on windows.