### PR TITLE
fix: equal bottom and top margin of the firmware upgrade error panel

### DIFF
--- a/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.html
+++ b/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.html
@@ -55,7 +55,7 @@
                 <p>
                     If your UHK is connected via a USB hub, docking station, or KVM switch, connect it
                     directly to your computer. It might also help to join the keyboard halves during the update.</p>
-                <p>
+                <p class="mb-0">
                     If you've tried the above and the update still keeps failing, please
                     <a class="link-github" [href]="firmwareGithubIssueUrl" externalUrl>create a GitHub issue</a>,
                     and attach the update log.


### PR DESCRIPTION
<img width="1168" alt="Screenshot 2021-05-10 at 19 02 20" src="https://user-images.githubusercontent.com/496775/117697368-b138e600-b1c2-11eb-811b-3234ad7bec4d.png">
