### PR TITLE
feat: simplify USB device list

### DIFF
--- a/packages/uhk-agent/src/services/device.service.ts
+++ b/packages/uhk-agent/src/services/device.service.ts
@@ -32,6 +32,7 @@ import {
     TmpFirmware,
     UhkHidDevice,
     UhkOperations,
+    usbDeviceJsonFormatter,
     waitForDevice
 } from 'uhk-usb';
 import { emptyDir } from 'fs-extra';
@@ -258,9 +259,8 @@ export class DeviceService {
             const hardwareModules = await this.getHardwareModules(false);
 
             await this.stopPollUhkDevice();
-            this.device.resetDeviceCache();
 
-            this.logService.misc('UHK Device firmware upgrade starts:', JSON.stringify(uhkDeviceProduct));
+            this.logService.misc('UHK Device firmware upgrade starts:', JSON.stringify(uhkDeviceProduct, usbDeviceJsonFormatter));
             const deviceFirmwarePath = getDeviceFirmwarePath(uhkDeviceProduct, packageJson);
 
             this.logService.misc('Device right firmware version:', hardwareModules.rightModuleInfo.firmwareVersion);
@@ -341,7 +341,9 @@ export class DeviceService {
             const uhkDeviceProduct = getCurrentUhkDeviceProductByBootloaderId();
             checkFirmwareAndDeviceCompatibility(packageJson, uhkDeviceProduct);
 
-            this.logService.misc('[DeviceService] UHK Device recovery starts:', JSON.stringify(uhkDeviceProduct));
+            this.logService.misc(
+                '[DeviceService] UHK Device recovery starts:',
+                JSON.stringify(uhkDeviceProduct, usbDeviceJsonFormatter));
             const deviceFirmwarePath = getDeviceFirmwarePath(uhkDeviceProduct, packageJson);
 
             await this.operations.updateRightFirmwareWithKboot(deviceFirmwarePath, uhkDeviceProduct);

--- a/packages/uhk-agent/src/util/reenumerate-and-exit.ts
+++ b/packages/uhk-agent/src/util/reenumerate-and-exit.ts
@@ -2,12 +2,12 @@ import {
     UhkHidDevice,
     EnumerationModes,
     getDeviceEnumerateProductId,
-    getCurrentUhkDeviceProduct
+    getCurrentUhkDeviceProduct,
+    getUhkDevices
 } from 'uhk-usb';
 import { CommandLineArgs } from 'uhk-common';
 
 import { ElectronLogService } from '../services/logger.service';
-import { devices } from 'node-hid';
 
 export interface ReenumerateAndExitOptions {
     logger: ElectronLogService;
@@ -20,7 +20,7 @@ export async function reenumerateAndExit(options: ReenumerateAndExitOptions): Pr
     options.logger.misc(`[reenumerateAndExit] Command line argument: ${arg}`);
 
     options.logger.misc('[reenumerateAndExit] list available devices');
-    options.uhkHidDevice.listAvailableDevices(devices());
+    options.uhkHidDevice.listAvailableDevices(getUhkDevices());
 
     const startTime = new Date();
     const reenumerationOption = parseReenumerateAndExitArg(arg);
@@ -39,7 +39,7 @@ export async function reenumerateAndExit(options: ReenumerateAndExitOptions): Pr
     const waitTime = reenumerationOption.timeout + 10000;
 
     while (new Date().getTime() - startTime.getTime() < waitTime) {
-        options.uhkHidDevice.listAvailableDevices(devices());
+        options.uhkHidDevice.listAvailableDevices(getUhkDevices());
     }
 }
 

--- a/packages/uhk-common/src/models/uhk-products.ts
+++ b/packages/uhk-common/src/models/uhk-products.ts
@@ -1,6 +1,8 @@
 import { ModuleSlotToI2cAddress } from './module-slot-to-i2c-adress';
 import { ModuleSlotToId } from './module-slot-id';
 
+export const UHK_VENDOR_ID = 0x1D50;
+
 export interface UhkDeviceProduct {
     id: number;
     // TODO: Maybe it is not necessary
@@ -17,7 +19,7 @@ export interface UhkDeviceProduct {
 export const UHK_60_DEVICE: UhkDeviceProduct = {
     id: 1,
     name: 'UHK 60 v1',
-    vendorId: 0x1D50,
+    vendorId: UHK_VENDOR_ID,
     keyboardPid: 0x6122,
     bootloaderPid: 0x6120,
     buspalPid: 0x6121
@@ -26,7 +28,7 @@ export const UHK_60_DEVICE: UhkDeviceProduct = {
 export const UHK_60_V2_DEVICE: UhkDeviceProduct = {
     id: 2,
     name: 'UHK 60 v2',
-    vendorId: 0x1D50,
+    vendorId: UHK_VENDOR_ID,
     keyboardPid: 0x6124,
     bootloaderPid: 0x6123,
     buspalPid: 0x6121

--- a/packages/uhk-usb/src/utils/get-uhk-devices.ts
+++ b/packages/uhk-usb/src/utils/get-uhk-devices.ts
@@ -1,0 +1,6 @@
+import { Device, devices } from 'node-hid';
+import { UHK_VENDOR_ID } from 'uhk-common';
+
+export function getUhkDevices(): Array<Device> {
+    return devices().filter(x => x.vendorId === UHK_VENDOR_ID);
+}

--- a/packages/uhk-usb/src/utils/index.ts
+++ b/packages/uhk-usb/src/utils/index.ts
@@ -9,4 +9,6 @@ export * from './get-firmware-package-json';
 export * from './get-module-firmware-path';
 export * from './get-number-of-connected-devices';
 export * from './get-package-json-from-path-async';
+export * from './get-uhk-devices';
 export * from './validate-connected-devices';
+export * from './usb-device-json-formatter';

--- a/packages/uhk-usb/src/utils/usb-device-json-formatter.ts
+++ b/packages/uhk-usb/src/utils/usb-device-json-formatter.ts
@@ -1,0 +1,16 @@
+import { toHexString } from 'uhk-common';
+
+export function usbDeviceJsonFormatter(key: any, value: any): any {
+    switch (key) {
+        case 'vendorId':
+        case 'productId':
+        case 'keyboardPid':
+        case 'bootloaderPid':
+        case 'buspalPid':
+            return toHexString(value);
+
+        default:
+            return value;
+    }
+
+}


### PR DESCRIPTION
closes: #1500 

Summary:
- show only UHK USB devices in the logs and the firmware upgrade screen
- log only "Added" and "Removed" UHK USB devices
- show the "vendorId" and "productId" in hex format
- not repeat the "Could not find reenumerated device: <Device>. Waiting..." and "Available devices unchanged" log messages. Instead of it add a `.` after "Waiting..."
  - before
  <img width="747" alt="Screenshot 2021-05-15 at 15 51 25" src="https://user-images.githubusercontent.com/496775/118364058-35aab080-b597-11eb-906f-efcfcaae8562.png">
  
  - after   
  <img width="781" alt="Screenshot 2021-05-15 at 15 54 13" src="https://user-images.githubusercontent.com/496775/118364069-3d6a5500-b597-11eb-9791-7d56d9f11519.png">
