### PR TITLE
chore: reorganise firmware upgrade logging

### DIFF
--- a/packages/uhk-common/src/util/get-slot-id-name.ts
+++ b/packages/uhk-common/src/util/get-slot-id-name.ts
@@ -1,0 +1,17 @@
+import { ModuleSlotToId } from '../models';
+
+export function getSlotIdName(slotId: ModuleSlotToId): string  {
+    switch (slotId) {
+        case ModuleSlotToId.leftHalf:
+            return 'leftHalf';
+
+        case ModuleSlotToId.leftModule:
+            return 'leftModule';
+
+        case ModuleSlotToId.rightModule:
+            return 'rightModule';
+
+        default:
+            return `Unknown slotId: ${slotId}`;
+    }
+}

--- a/packages/uhk-common/src/util/index.ts
+++ b/packages/uhk-common/src/util/index.ts
@@ -3,6 +3,7 @@ export * from './constants';
 export * from './create-md5-hash';
 export * from './find-uhk-module-by-id';
 export * from './get-md5-hash-from-file-name';
+export * from './get-slot-id-name';
 export * from './helpers';
 export * from './is-equal-array';
 export * from './map-i2c-address-to-module-name';

--- a/packages/uhk-usb/src/uhk-operations.ts
+++ b/packages/uhk-usb/src/uhk-operations.ts
@@ -1,6 +1,7 @@
 import {
     Buffer,
     ConfigSizesInfo,
+    getSlotIdName,
     HardwareConfiguration,
     LEFT_HALF_MODULE,
     LogService,
@@ -22,7 +23,6 @@ import {
     UsbVariables
 } from './constants';
 import * as fs from 'fs';
-import * as os from 'os';
 import { promisify } from 'util';
 import { UhkHidDevice } from './uhk-hid-device';
 import { readBootloaderFirmwareFromHexFileAsync, snooze, waitForDevice } from './util';
@@ -48,7 +48,6 @@ export class UhkOperations {
             throw new Error(`Firmware path not found: ${firmwarePath}`);
         }
 
-        this.logService.misc(`[UhkOperations] Operating system: ${os.type()} ${os.release()} ${os.arch()}`);
         this.logService.misc('[UhkOperations] Start flashing right firmware');
 
         this.logService.misc('[UhkOperations] Reenumerate bootloader');
@@ -354,9 +353,9 @@ export class UhkOperations {
     }
 
     public async getModuleVersionInfo(module: ModuleSlotToId): Promise<ModuleVersionInfo> {
+        const moduleSlotName = getSlotIdName(module);
         try {
-
-            this.logService.misc(`[DeviceOperation] Read "${module}" version information`);
+            this.logService.misc(`[DeviceOperation] Read "${moduleSlotName}" version information`);
             this.logService.usb('[DeviceOperation] USB[T]: Read module version information');
 
             const command = Buffer.from([
@@ -375,7 +374,7 @@ export class UhkOperations {
                 firmwareVersion: `${uhkBuffer.readUInt16()}.${uhkBuffer.readUInt16()}.${uhkBuffer.readUInt16()}`
             };
         } catch (error) {
-            this.logService.error(`[DeviceOperation] Could not read "${module}" version information`, error);
+            this.logService.error(`[DeviceOperation] Could not read "${moduleSlotName}" version information`, error);
         }
 
         return {


### PR DESCRIPTION
Summary:
- log the OS version and architecture
- add the `[DeviceService] ` prefix to the firmware upgrade logs
- log the module slot name instead of the id