### PR TITLE
fix: refactor generic layout

### DIFF
--- a/packages/uhk-web/src/app/app.component.html
+++ b/packages/uhk-web/src/app/app.component.html
@@ -1,25 +1,26 @@
-<app-update-available *ngIf="showUpdateAvailable"
-                      [@updateAvailable]
-                      [updateInfo]="updateInfo$ | async"
-                      (updateApp)="updateApp()"
-                      (doNotUpdateApp)="doNotUpdateApp()">
-</app-update-available>
+<div class="main-div" [class.update-panel-visible]="showUpdateAvailable">
+    <app-update-available *ngIf="showUpdateAvailable"
+                          [@updateAvailable]
+                          [updateInfo]="updateInfo$ | async"
+                          (updateApp)="updateApp()"
+                          (doNotUpdateApp)="doNotUpdateApp()">
+    </app-update-available>
 
-<side-menu [deviceConfigurationLoaded] = "deviceConfigurationLoaded$ | async"
-           [class.update-panel-visible]="showUpdateAvailable"></side-menu>
+    <side-menu [deviceConfigurationLoaded] = "deviceConfigurationLoaded$ | async"
+    ></side-menu>
 
-<div class="secondary-menu-wrapper"
-     [class.visible]="secondSideMenuVisible"
-     [class.update-panel-visible]="showUpdateAvailable">
-    <second-side-menu-container>
-    </second-side-menu-container>
-</div>
+    <div class="secondary-menu-wrapper"
+         [class.visible]="secondSideMenuVisible">
+        <second-side-menu-container>
+        </second-side-menu-container>
+    </div>
 
-<div id="main-content"
-     class="main-content inner-content "
-     [class.update-panel-visible]="showUpdateAvailable"
-     [class.second-menu-visible]="secondSideMenuVisible">
-    <router-outlet></router-outlet>
+    <div class="inner-content"
+         [class.update-panel-visible]="showUpdateAvailable"
+         [class.second-menu-visible]="secondSideMenuVisible">
+        <router-outlet></router-outlet>
+    </div>
+
 </div>
 <notifier-container></notifier-container>
 <highlight-arrow *ngIf="firstAttemptOfSaveToKeyboard$ | async" [@highlightArrow]></highlight-arrow>

--- a/packages/uhk-web/src/app/app.component.scss
+++ b/packages/uhk-web/src/app/app.component.scss
@@ -1,12 +1,18 @@
 @import '../styles/variables';
 @import '../styles/mixins';
 
-main-app {
+.main-div {
     min-height: 100%;
     height: 100%;
-    width: 100%;
-    display: block;
-    position: relative;
+}
+
+app-update-available {
+    height: $main-content-top-margin-on-update;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
 }
 
 .save-to-keyboard-button {
@@ -16,11 +22,27 @@ main-app {
 }
 
 .inner-content {
+    overflow-x: hidden;
     margin-left: $side-menu-width;
+    min-height: 100vh;
+    transition-timing-function: ease-out;
+    transition: 0.5s;
 
     &.second-menu-visible {
         margin-left: $side-menu-width + $second-side-menu-width;
+    }
 
+    & > :not(router-outlet) {
+        display: block;
+        height: 100%;
+        min-height: 100vh;
+        width: 100%;
+
+        &.vertical-center-component {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+        }
     }
 }
 
@@ -33,8 +55,8 @@ main-app {
     overflow-y: auto;
     overflow-x: hidden;
     top: 0;
-
-    @include updatePanelVisible();
+    transition-timing-function: ease-out;
+    transition: 0.5s;
 
     &.visible {
         width: $second-side-menu-width;
@@ -44,5 +66,18 @@ main-app {
     second-side-menu-container {
         width: $second-side-menu-width;
         display: block;
+    }
+}
+
+.update-panel-visible .secondary-menu-wrapper,
+.update-panel-visible side-menu {
+    top: $main-content-top-margin-on-update;
+}
+
+.update-panel-visible .inner-content {
+    padding-top: $main-content-top-margin-on-update;
+
+    & > :not(router-outlet) {
+        min-height: calc(100vh - #{$main-content-top-margin-on-update});
     }
 }

--- a/packages/uhk-web/src/app/components/device/configuration/device-configuration.component.scss
+++ b/packages/uhk-web/src/app/components/device/configuration/device-configuration.component.scss
@@ -1,9 +1,5 @@
 :host {
     overflow-y: auto;
-    display: block;
-    height: 100vh;
-    min-height: 100%;
-    width: 100%;
 
     p {
         margin: 1.5rem 0;

--- a/packages/uhk-web/src/app/components/device/configuration/device-configuration.component.ts
+++ b/packages/uhk-web/src/app/components/device/configuration/device-configuration.component.ts
@@ -22,7 +22,7 @@ import {
     templateUrl: './device-configuration.component.html',
     styleUrls: ['./device-configuration.component.scss'],
     host: {
-        'class': 'container-fluid'
+        'class': 'container-fluid full-screen-component'
     }
 })
 export class DeviceConfigurationComponent implements OnInit, OnDestroy {

--- a/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.scss
+++ b/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.scss
@@ -1,11 +1,3 @@
-:host {
-    overflow-y: auto;
-    display: block;
-    height: 100vh;
-    min-height: 100%;
-    width: 100%;
-}
-
 .link-github {
     cursor: pointer;
 }

--- a/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.ts
+++ b/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.ts
@@ -25,7 +25,7 @@ import { FirmwareUpgradeState, HistoryFileInfo, ModuleFirmwareUpgradeState, Upda
     templateUrl: './device-firmware.component.html',
     styleUrls: ['./device-firmware.component.scss'],
     host: {
-        'class': 'container-fluid'
+        'class': 'container-fluid full-screen-component'
     }
 })
 export class DeviceFirmwareComponent implements OnDestroy {

--- a/packages/uhk-web/src/app/components/device/recovery-mode/recovery-mode.component.scss
+++ b/packages/uhk-web/src/app/components/device/recovery-mode/recovery-mode.component.scss
@@ -1,8 +1,13 @@
+@import '../../../../styles/variables';
+
 :host {
-    overflow-y: auto;
-    display: block;
-    height: 100%;
-    width: 100%;
+    .flex-container {
+        height: 100vh;
+    }
+
+    .update-panel-visible .flex-container {
+        height: calc(100vh - #{$main-content-top-margin-on-update});
+    }
 
     p {
         margin: 1.5rem 0;

--- a/packages/uhk-web/src/app/components/device/recovery-mode/recovery-mode.component.ts
+++ b/packages/uhk-web/src/app/components/device/recovery-mode/recovery-mode.component.ts
@@ -13,7 +13,7 @@ import { RecoveryDeviceAction } from '../../../store/actions/device';
     templateUrl: './recovery-mode.component.html',
     styleUrls: ['./recovery-mode.component.scss'],
     host: {
-        'class': 'container-fluid'
+        'class': 'container-fluid full-screen-component'
     }
 })
 export class RecoveryModeComponent implements OnInit {

--- a/packages/uhk-web/src/app/components/missing-device/missing-device.component.ts
+++ b/packages/uhk-web/src/app/components/missing-device/missing-device.component.ts
@@ -7,7 +7,10 @@ import { MissingDeviceState } from '../../models/missing-device-state';
 
 @Component({
     selector: 'missing-device',
-    templateUrl: './missing-device.component.html'
+    templateUrl: './missing-device.component.html',
+    host: {
+        'class': 'container-fluid vertical-center-component'
+    }
 })
 export class MissingDeviceComponent implements OnDestroy {
 

--- a/packages/uhk-web/src/app/components/privilege-checker/privilege-checker.component.html
+++ b/packages/uhk-web/src/app/components/privilege-checker/privilege-checker.component.html
@@ -1,4 +1,4 @@
-<div class="privilege-checker-wrapper">
+<div class="justify-content-center">
     <ng-container [ngSwitch]="platform">
         <mac-privilege-checker *ngSwitchCase="'darwin'"></mac-privilege-checker>
 

--- a/packages/uhk-web/src/app/components/privilege-checker/privilege-checker.component.scss
+++ b/packages/uhk-web/src/app/components/privilege-checker/privilege-checker.component.scss
@@ -1,11 +1,3 @@
-.privilege-checker-wrapper {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-}
-
 mac-privilege-checker,
 linux-privilege-checker {
     max-width: 80%;

--- a/packages/uhk-web/src/app/components/privilege-checker/privilege-checker.component.ts
+++ b/packages/uhk-web/src/app/components/privilege-checker/privilege-checker.component.ts
@@ -11,7 +11,10 @@ import { PrivilagePageSate } from '../../models/privilage-page-sate';
     selector: 'privilege-checker',
     changeDetection: ChangeDetectionStrategy.OnPush,
     templateUrl: './privilege-checker.component.html',
-    styleUrls: ['./privilege-checker.component.scss']
+    styleUrls: ['./privilege-checker.component.scss'],
+    host: {
+        'class': 'container-fluid vertical-center-component'
+    }
 })
 
 export class PrivilegeCheckerComponent implements OnInit, OnDestroy {

--- a/packages/uhk-web/src/app/components/side-menu/side-menu.component.scss
+++ b/packages/uhk-web/src/app/components/side-menu/side-menu.component.scss
@@ -11,10 +11,10 @@ $level-2-item-spacing: 0.125rem 0 0.125rem 2rem;
     position: fixed;
     overflow-y: auto;
     top: 0;
+    bottom: 0;
     width: $side-menu-width;
-    height: 100%;
-
-    @include updatePanelVisible();
+    transition-timing-function: ease-out;
+    transition: 0.5s;
 }
 
 a {

--- a/packages/uhk-web/src/app/pages/loading-page/loading-device.page.ts
+++ b/packages/uhk-web/src/app/pages/loading-page/loading-device.page.ts
@@ -7,7 +7,10 @@ import { Component } from '@angular/core';
                      subtitle="Hang tight!"
                      [showLogo]="true"
                      [rotateLogo]="true"></uhk-message>
-    `
+    `,
+    host: {
+        'class': 'container-fluid vertical-center-component'
+    }
 })
 export class LoadingDevicePageComponent {
 

--- a/packages/uhk-web/src/app/pages/main-page/main.page.html
+++ b/packages/uhk-web/src/app/pages/main-page/main.page.html
@@ -1,3 +1,1 @@
-<div class="main-page-content">
-    <router-outlet (activate)="onActivate($event, outlet)" #outlet></router-outlet>
-</div>
+<router-outlet (activate)="onActivate($event, outlet)" #outlet></router-outlet>

--- a/packages/uhk-web/src/app/pages/main-page/main.page.ts
+++ b/packages/uhk-web/src/app/pages/main-page/main.page.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
     selector: 'main-page',
-    templateUrl: './main.page.html',
-    styles: [':host{height:100%; width:100%}']
+    templateUrl: './main.page.html'
 })
 export class MainPage {
 

--- a/packages/uhk-web/src/app/pages/multi-device.page.ts
+++ b/packages/uhk-web/src/app/pages/multi-device.page.ts
@@ -8,6 +8,9 @@ import { Component } from '@angular/core';
                      [showLogo]="true"
                      [smallText]="true"
         ></uhk-message>
-    `
+    `,
+    host: {
+        'class': 'container-fluid vertical-center-component'
+    }
 })
 export class MultiDevicePageComponent {}

--- a/packages/uhk-web/src/styles/_global.scss
+++ b/packages/uhk-web/src/styles/_global.scss
@@ -1,10 +1,34 @@
+@import './variables';
 
 /* You can add global styles to this file, and also import other style files */
 
-html, body {
-    width: 100%;
+html {
+    min-height: 100%;
+    height: 100%;
+}
+
+body {
+    margin: 0;
     height: 100%;
     --macro-sub-item-max-width: 175px;
+}
+
+main-app {
+    display: block;
+    min-height: 100%;
+}
+
+.full-screen-component {
+    display: block;
+    height: 100vh;
+}
+
+.update-panel-visible {
+    transition-timing-function: ease-out;
+    transition: 0.5s;
+}
+.update-panel-visible .full-screen-component {
+    height: calc(100vh - #{$main-content-top-margin-on-update});
 }
 
 textarea {
@@ -16,18 +40,6 @@ textarea {
     -ms-transform: rotate(90deg); /* IE 9 */
     -webkit-transform: rotate(90deg); /* Chrome, Safari, Opera */
     transform: rotate(90deg); // svg not aligned properly
-}
-
-.main-content {
-    height: 100%;
-    top: 0;
-
-    @include updatePanelVisible();
-}
-
-.main-page-content {
-    overflow-x: hidden;
-    min-height: 100%;
 }
 
 app-update-available {

--- a/packages/uhk-web/src/styles/_mixins.scss
+++ b/packages/uhk-web/src/styles/_mixins.scss
@@ -11,18 +11,6 @@
     }
 }
 
-@mixin updatePanelVisible() {
-    transition-timing-function: ease-out;
-    transition: 0.5s;
-    margin-top: 0;
-
-    &.update-panel-visible {
-        transition-timing-function: ease-in;
-        transition: 0.5s;
-        margin-top: $main-content-top-margin-on-update;
-    }
-}
-
 @mixin invertInDarkTheme($percentage) {
     @if ($dark-theme) {
         filter: invert($percentage);

--- a/packages/uhk-web/src/styles/_variables.scss
+++ b/packages/uhk-web/src/styles/_variables.scss
@@ -35,7 +35,7 @@ $btn-focus-width: 0;
 // UHK app variables
 
 $update-notification-height: 35px;
-$main-content-top-margin-on-update: 35px + 10px;
+$main-content-top-margin-on-update: $update-notification-height + 10px;
 $icon-dark-theme-inversion: 70%;
 $side-menu-width: 250px;
 $second-side-menu-width: 250px;


### PR DESCRIPTION
closes: #1603

The easiest way to test the firmware upgrade while the update panel is visible : modify the [line](https://github.com/UltimateHackingKeyboard/agent/blob/3990877496dc273f7a066ad61c0b27398e8bfc0a/packages/uhk-web/src/app/store/reducers/app-update.reducer.ts#L51)
 ```typescript
export const getShowAppUpdateAvailable = (state: State) => true;
``` 