### PR TITLE
feat: show "Same as current" for every current row after the first "Current" row in the user configuration history.

### DIFF
--- a/packages/uhk-web/src/app/components/user-configuration-history/user-configuration-history.component.html
+++ b/packages/uhk-web/src/app/components/user-configuration-history/user-configuration-history.component.html
@@ -26,12 +26,12 @@
                       *ngIf="fileInfo.showRestore"
                       (click)="getUserConfigFromHistory.emit(fileInfo.file)"
                       [class.disabled]="state.disabled">
-                            Restore
+                            {{ fileInfo.displayText }}
                 </span>
 
                 <span class="btn btn-link btn-padding-0 current"
                       *ngIf="!fileInfo.showRestore">
-                            Current
+                            {{ fileInfo.displayText }}
                 </span>
             </li>
         </ul>

--- a/packages/uhk-web/src/app/components/user-configuration-history/user-configuration-history.component.ts
+++ b/packages/uhk-web/src/app/components/user-configuration-history/user-configuration-history.component.ts
@@ -10,7 +10,6 @@ import { HistoryFileInfo, UserConfigHistoryComponentState } from '../../models';
 })
 export class UserConfigurationHistoryComponent {
     @Input() state: UserConfigHistoryComponentState;
-    @Input() md5HasOfCurrentConfig: string;
 
     @Output() getUserConfigFromHistory = new EventEmitter<string>();
 

--- a/packages/uhk-web/src/app/models/user-config-history-component-state.ts
+++ b/packages/uhk-web/src/app/models/user-config-history-component-state.ts
@@ -1,5 +1,15 @@
 export interface HistoryFileInfo {
+    /**
+     * The filename of the saved user configuration
+     */
     file: string;
+    /**
+     * Text that will show in the 2nd column as
+     *   - Current
+     *   - Same as current
+     *   - Restore
+     */
+    displayText: string;
     showRestore: boolean;
 }
 

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -358,12 +358,29 @@ export const getUserConfigHistoryComponentState = createSelector(
      state: fromUserConfigHistory.State,
      md5Hash: string,
      saving: boolean): UserConfigHistoryComponentState => {
+        let foundFirstCurrent = false;
+
         return {
             loading: inElectron && state.loading,
-            files: state.files.map(x => ({
-                file: x,
-                showRestore: getMd5HashFromFilename(x) !== md5Hash
-            })),
+            files: state.files.map(x => {
+                const showRestore = getMd5HashFromFilename(x) !== md5Hash;
+                let displayText: string;
+
+                if (showRestore) {
+                    displayText = 'Restore';
+                } else if (foundFirstCurrent) {
+                    displayText = 'Same as current';
+                } else {
+                    displayText = 'Current';
+                    foundFirstCurrent = true;
+                }
+
+                return {
+                    displayText,
+                    showRestore,
+                    file: x
+                };
+            }),
             disabled: saving
         };
     });


### PR DESCRIPTION
close #1612