### PR TITLE
refactor: selected macro logic

### DIFF
--- a/packages/uhk-web/src/app/components/auto-grow-input/auto-grow-input.component.ts
+++ b/packages/uhk-web/src/app/components/auto-grow-input/auto-grow-input.component.ts
@@ -6,7 +6,9 @@ import {
     ElementRef,
     forwardRef, HostListener,
     Input,
+    OnChanges,
     Renderer2,
+    SimpleChanges,
     ViewChild
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -28,7 +30,7 @@ const noop = (_: any) => {
     ],
     styleUrls: ['./auto-grow-input.component.scss']
 })
-export class AutoGrowInputComponent implements ControlValueAccessor, AfterViewInit {
+export class AutoGrowInputComponent implements ControlValueAccessor, AfterViewInit, OnChanges {
     @Input() maxParentWidthPercent;
     @Input() maxParentWidthOffset;
     @Input() minWidth: number = 100;
@@ -61,8 +63,18 @@ export class AutoGrowInputComponent implements ControlValueAccessor, AfterViewIn
                 private _renderer: Renderer2) {
     }
 
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes.selectAfterInit.currentValue) {
+            this.selectContent();
+        }
+    }
+
     ngAfterViewInit(): void {
-        if (this.selectAfterInit) {
+        this.selectContent();
+    }
+
+    selectContent(): void {
+        if (this.selectAfterInit && this.inputControl) {
             setTimeout(() => {
                 this.inputControl.nativeElement.select();
                 this.selectAfterInit = false;

--- a/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.html
+++ b/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.html
@@ -1,7 +1,7 @@
 <ng-template [ngIf]="macro">
     <macro-header
             [macro]="macro"
-            [isNew]="isNew"
+            [isNew]="isNew$ | async"
     ></macro-header>
     <macro-list
         [macro]="macro"

--- a/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.ts
+++ b/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.ts
@@ -4,16 +4,14 @@ import { Store } from '@ngrx/store';
 import { Macro, MacroAction } from 'uhk-common';
 
 import { Observable, Subscription } from 'rxjs';
-import { pluck } from 'rxjs/operators';
 
 import {
     AddMacroActionAction,
     DeleteMacroActionAction,
     ReorderMacroActionAction,
-    SaveMacroActionAction,
-    SelectMacroAction
+    SaveMacroActionAction
 } from '../../../store/actions/macro';
-import { AppState, getSelectedMacro, isMacroCommandSupported, macroPlaybackSupported } from '../../../store';
+import { AppState, getSelectedMacro, isMacroCommandSupported, isSelectedMacroNew, macroPlaybackSupported } from '../../../store';
 
 @Component({
     selector: 'macro-edit',
@@ -26,39 +24,29 @@ import { AppState, getSelectedMacro, isMacroCommandSupported, macroPlaybackSuppo
 })
 export class MacroEditComponent implements OnDestroy {
     macro: Macro;
-    isNew: boolean;
+    isNew$: Observable<boolean>;
     macroId: number;
     macroPlaybackSupported$: Observable<boolean>;
     isMacroCommandSupported$: Observable<boolean>;
 
     private selectedMacroSubscription: Subscription;
-    private routeSubscription: Subscription;
 
     constructor(private store: Store<AppState>,
                 private cdRef: ChangeDetectorRef,
                 public route: ActivatedRoute) {
-
-        this.routeSubscription = route
-            .params
-            .pipe(
-                pluck<{}, string>('id')
-            )
-            .subscribe(id => store.dispatch(new SelectMacroAction(+id)));
-
         this.selectedMacroSubscription = store.select(getSelectedMacro)
             .subscribe((macro: Macro) => {
                 this.macro = macro;
                 this.cdRef.markForCheck();
             });
 
-        this.isNew = this.route.snapshot.params['empty'] === 'new';
+        this.isNew$ = this.store.select(isSelectedMacroNew);
         this.macroPlaybackSupported$ = this.store.select(macroPlaybackSupported);
         this.isMacroCommandSupported$ = this.store.select(isMacroCommandSupported);
     }
 
     ngOnDestroy() {
         this.selectedMacroSubscription.unsubscribe();
-        this.routeSubscription.unsubscribe();
     }
 
     addAction(macroId: number, action: MacroAction) {

--- a/packages/uhk-web/src/app/components/macro/macro.routes.ts
+++ b/packages/uhk-web/src/app/components/macro/macro.routes.ts
@@ -10,11 +10,7 @@ export const macroRoutes: Routes = [
         canActivate: [MacroNotFoundGuard]
     },
     {
-        path: 'macro/:id',
-        component: MacroEditComponent
-    },
-    {
-        path: 'macro/:id/:empty',
+        path: 'macro/:macroId',
         component: MacroEditComponent
     }
 ];

--- a/packages/uhk-web/src/app/store/effects/macro.ts
+++ b/packages/uhk-web/src/app/store/effects/macro.ts
@@ -1,53 +1,54 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 
-import { Actions, Effect, ofType } from '@ngrx/effects';
-import { Store, Action } from '@ngrx/store';
-import { map, pairwise, tap, withLatestFrom } from 'rxjs/operators';
+import { Actions, createEffect, Effect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { routerNavigatedAction } from '@ngrx/router-store';
+import { distinctUntilChanged, map, tap, withLatestFrom } from 'rxjs/operators';
 
 import { Macro } from 'uhk-common';
 import * as Keymaps from '../actions/keymap';
 import * as Macros from '../actions/macro';
-import { AppState, getSelectedMacroIdAfterRemove, getMacros } from '..';
-import { findNewItem } from '../../util';
+import { AppState, getSelectedMacro } from '..';
+import { SelectMacroAction } from '../actions/macro';
 
 @Injectable()
 export class MacroEffects {
+
+    macroNavigated$ = createEffect(() => this.actions$
+        .pipe(
+            ofType(routerNavigatedAction),
+            map(action => (action.payload.routerState as any).params.macroId),
+            distinctUntilChanged(),
+            map(macroId => new SelectMacroAction(+macroId))
+        ));
 
     @Effect({ dispatch: false }) remove$: any = this.actions$
         .pipe(
             ofType<Macros.RemoveMacroAction>(Macros.ActionTypes.Remove),
             tap(action => this.store.dispatch(new Keymaps.CheckMacroAction(action.payload))),
-            withLatestFrom(this.store.select(getSelectedMacroIdAfterRemove)),
-            map(([, newMacroId]) => newMacroId),
-            tap(newMacroId => {
-                if (newMacroId) {
-                    return this.router.navigate(['/macro', newMacroId]);
-                }
+            withLatestFrom(this.store.select(getSelectedMacro)),
+            map(([, newMacro]) => newMacro),
+            tap(this.navigateToNewMacro.bind(this))
 
-                return this.router.navigate(['/macro']);
-            })
         );
 
     @Effect({ dispatch: false }) addOrDuplicate$: any = this.actions$
         .pipe(
             ofType<Macros.AddMacroAction | Macros.DuplicateMacroAction>(
                 Macros.ActionTypes.Add, Macros.ActionTypes.Duplicate),
-            withLatestFrom(this.store.select(getMacros)
-                .pipe(
-                    pairwise()
-                )
-            ),
-            map(([action, latest]: [Action, Macro[][]]) => ([action, latest[0], latest[1]])),
-            tap(([action, prevMacros, newMacros]: [Action, Macro[], Macro[]]) => {
-                const newMacro = findNewItem(prevMacros, newMacros);
-                const commands = ['/macro', newMacro.id];
-                if (action.type === Macros.ActionTypes.Add) {
-                    commands.push('new');
-                }
-                this.router.navigate(commands);
-            })
+            withLatestFrom(this.store.select(getSelectedMacro)),
+            map(([, newMacro]) => newMacro),
+            tap(this.navigateToNewMacro.bind(this))
         );
+
+    private navigateToNewMacro(newMacro: Macro): Promise<boolean> {
+        if (newMacro) {
+            return this.router.navigate(['/macro', newMacro.id]);
+        }
+
+        return this.router.navigate(['/macro']);
+    }
 
     constructor(private actions$: Actions,
                 private router: Router,

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -81,11 +81,11 @@ export const getDefaultKeymap = createSelector(userConfigState, fromUserConfig.g
 export const getSelectedKeymap = createSelector(userConfigState, fromUserConfig.getSelectedKeymap);
 export const getMacros = createSelector(userConfigState, fromUserConfig.getMacros);
 export const getSelectedMacro = createSelector(userConfigState, fromUserConfig.getSelectedMacro);
+export const isSelectedMacroNew = createSelector(userConfigState, fromUserConfig.isSelectedMacroNew);
 export const isKeymapDeletable = createSelector(userConfigState, fromUserConfig.isKeymapDeletable);
 export const hasMacro = createSelector(userConfigState, fromUserConfig.hasMacro);
 export const getMacroMap = createSelector(userConfigState, fromUserConfig.getMacroMap);
 export const lastEditedKey = createSelector(userConfigState, fromUserConfig.lastEditedKey);
-export const getSelectedMacroIdAfterRemove = createSelector(userConfigState, fromUserConfig.getSelectedMacroIdAfterRemove);
 export const getSelectedLayerOption = createSelector(userConfigState, fromUserConfig.getSelectedLayerOption);
 export const getLayerOptions = createSelector(userConfigState, fromUserConfig.getLayerOptions);
 export const getKeymapOptions = createSelector(getKeymaps, getSelectedKeymap, (keymaps, selectedKeymap): SelectOptionData[] => {

--- a/packages/uhk-web/src/app/store/reducers/user-configuration.ts
+++ b/packages/uhk-web/src/app/store/reducers/user-configuration.ts
@@ -31,6 +31,7 @@ import * as Device from '../actions/device';
 import { getBaseLayerOption, initLayerOptions } from './layer-options';
 
 export interface State {
+    isSelectedMacroNew: boolean;
     userConfiguration: UserConfiguration;
     selectedKeymapAbbr?: string;
     selectedMacroId?: number;
@@ -38,10 +39,10 @@ export interface State {
     layerOptions: Map<number, LayerOption>;
     halvesInfo: HalvesInfo;
     selectedLayerOption: LayerOption;
-    selectedMacroIdAfterRemove?: number;
 }
 
 export const initialState: State = {
+    isSelectedMacroNew: false,
     userConfiguration: new UserConfiguration(),
     lastEditedKey: defaultLastEditKey(),
     layerOptions: initLayerOptions(),
@@ -444,7 +445,9 @@ export function reducer(
 
             return {
                 ...state,
-                userConfiguration
+                userConfiguration,
+                selectedMacroId: newMacro.id,
+                isSelectedMacroNew: true
             };
         }
 
@@ -459,7 +462,8 @@ export function reducer(
 
             return {
                 ...state,
-                userConfiguration
+                userConfiguration,
+                selectedMacroId: newMacro.id
             };
         }
 
@@ -500,7 +504,7 @@ export function reducer(
         case MacroActions.ActionTypes.Remove: {
             const newState = {
                 ...state,
-                selectedMacroIdAfterRemove: undefined
+                selectedMacroId: undefined
             };
             const macroId = (action as MacroActions.RemoveMacroAction).payload;
             const userConfiguration = state.userConfiguration.clone();
@@ -511,10 +515,10 @@ export function reducer(
                 if (macroId === macro.id) {
                     if (idx === lastMacroIdx) {
                         if (state.userConfiguration.macros.length > 1) {
-                            newState.selectedMacroIdAfterRemove = state.userConfiguration.macros[idx - 1].id;
+                            newState.selectedMacroId = state.userConfiguration.macros[idx - 1].id;
                         }
                     } else {
-                        newState.selectedMacroIdAfterRemove = state.userConfiguration.macros[idx + 1].id;
+                        newState.selectedMacroId = state.userConfiguration.macros[idx + 1].id;
                     }
                 } else {
                     userConfiguration.macros.push(macro);
@@ -687,6 +691,7 @@ export function reducer(
             return {
                 ...state,
                 selectedMacroId,
+                isSelectedMacroNew: false
             };
         }
         default:
@@ -712,6 +717,7 @@ export const getSelectedMacro = (state: State): Macro => {
 
     return state.userConfiguration.macros.find(macro => macro.id === state.selectedMacroId);
 };
+export const isSelectedMacroNew = (state: State): boolean => state.isSelectedMacroNew;
 export const isKeymapDeletable = (state: State): boolean => state.userConfiguration.keymaps.length > 1;
 export const hasMacro = (state: State): boolean => state.userConfiguration.macros.length > 0;
 export const reduceMacroToMap = (map: Map<number, Macro>, macro: Macro) => map.set(macro.id, macro);
@@ -719,7 +725,6 @@ export const getMacroMap = (state: State): Map<number, Macro> => {
     return state.userConfiguration.macros.reduce(reduceMacroToMap, new Map());
 };
 export const lastEditedKey = (state: State): LastEditedKey => state.lastEditedKey;
-export const getSelectedMacroIdAfterRemove = (state: State): number | undefined => state.selectedMacroIdAfterRemove;
 export const getLayerOptions = (state: State): LayerOption[] => Array
     .from(state.layerOptions.values())
     .sort((a, b) => a.order - b.order);


### PR DESCRIPTION
Summary:
- create `macroNavigated$` effect to detect the selected macro ID
- replace `selectedMacroIdAfterRemove` with `selectedMacroId` in user-configuration state
- fix content selection of the AutoGrowInputComponent
