### PR TITLE
fix: z-index of the save to keyboard button

### DIFF
--- a/packages/uhk-web/src/app/app.component.scss
+++ b/packages/uhk-web/src/app/app.component.scss
@@ -19,6 +19,7 @@ app-update-available {
     position: fixed;
     bottom: 15px;
     right: 15px;
+    z-index: 25;
 }
 
 .inner-content {


### PR DESCRIPTION
before
<img width="690" alt="Screenshot 2022-02-17 at 20 29 49" src="https://user-images.githubusercontent.com/496775/154558714-18cc56d7-c63d-4bd2-802b-bc499bc9bd31.png">

after
<img width="560" alt="Screenshot 2022-02-17 at 20 44 11" src="https://user-images.githubusercontent.com/496775/154558695-739f0cf4-f743-4b3f-bba5-4f16c057fd52.png">
