### PR TITLE
feat: open smart macro doc links in browser

### DIFF
--- a/packages/uhk-web/src/app/store/effects/smart-macro-doc.effect.ts
+++ b/packages/uhk-web/src/app/store/effects/smart-macro-doc.effect.ts
@@ -1,24 +1,45 @@
 import { Injectable } from '@angular/core';
-import { Action } from '@ngrx/store';
+import { Action, Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { tap, withLatestFrom } from 'rxjs/operators';
 
 import { SmartMacroDocRendererService } from '../../services/smart-macro-doc-renderer.service';
 import { SmartMacroDocService } from '../../services/smart-macro-doc-service';
+import * as Device from '../actions/device';
 import { ActionTypes } from '../actions/smart-macro-doc.action';
+import { AppState, getSmartMacroDocModuleIds } from '../index';
 
 @Injectable()
 export class SmartMacroDocEffect {
 
-    @Effect({dispatch: false}) appStart$: Observable<Action> = this.actions$
+    @Effect({ dispatch: false }) appStart$: Observable<Action> = this.actions$
         .pipe(
             ofType(ActionTypes.TogglePanelVisibility),
             tap(() => this.smartMacroDocRendererService.downloadDocumentation())
         );
 
+    @Effect({ dispatch: false }) smartMacroDocInited$ = this.actions$
+        .pipe(
+            ofType(ActionTypes.SmdInited, Device.ActionTypes.ModulesInfoLoaded, Device.ActionTypes.ConnectionStateChanged,
+                Device.ActionTypes.UpdateFirmwareSuccess, Device.ActionTypes.UpdateFirmwareFailed),
+            withLatestFrom(this.store.select(getSmartMacroDocModuleIds)),
+            tap(([, modules]) => this.sendMessageContext(modules))
+        );
+
     constructor(private actions$: Actions,
                 private smartMacroDocRendererService: SmartMacroDocRendererService,
-                private smartMacroDocService: SmartMacroDocService) {
+                private smartMacroDocService: SmartMacroDocService,
+                private store: Store<AppState>) {
+
+    }
+
+    private sendMessageContext(modulesIds: Array<number>): void {
+        this.smartMacroDocService.sendMessage({
+            action: 'agent-message-context',
+            isRunningInAgent: true,
+            modules: modulesIds,
+            version: '1.0.0'
+        });
     }
 }


### PR DESCRIPTION
Summary
 - introduced the `agent-message-context` event. The event will dispatch if any of the message property changes. Currently, the `modules` relevant
 - removed the `modules` property from the `gent-message-editor-got-focus` and `agent-message-editor-lost-focus` actions
 - introduced the `doc-message-open-link` action. Parameters of the message:
   - 'url': Agent will open the URL in a browser window