### PR TITLE
fix: scancode field not updated from Capture keystroke if dropdown was opened

### DIFF
--- a/packages/uhk-web/src/app/components/popover/tab/keypress/keypress-tab.component.ts
+++ b/packages/uhk-web/src/app/components/popover/tab/keypress/keypress-tab.component.ts
@@ -117,6 +117,7 @@ export class KeypressTabComponent extends Tab implements OnChanges {
         this.leftModifiers = event.left;
         this.rightModifiers = event.right;
         this.keyActionChanged();
+        this.scancodeSelect.searchTerm = this.selectedScancodeOption.text || '';
     }
 
     fromKeyAction(keyAction: KeyAction): boolean {


### PR DESCRIPTION
close #1793