### PR TITLE
fix: detect non ASCII character keydown in macro-command-editor

### DIFF
--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command-editor.component.ts
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command-editor.component.ts
@@ -20,8 +20,8 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 import { SelectedMacroActionId } from '../../../../../models';
 import { SmartMacroDocCommandAction, SmartMacroDocService } from '../../../../../services/smart-macro-doc-service';
+import { NON_ASCII_REGEXP } from '../../../../../util';
 
-const NON_ASCII_REGEXP = /[^\x00-\x7F]/g;
 const MONACO_EDITOR_LINE_HEIGHT_OPTION = 59;
 const MACRO_CHANGE_DEBOUNCE_TIME = 250;
 
@@ -150,7 +150,7 @@ export class MacroCommandEditorComponent implements AfterViewInit, ControlValueA
             this.isFocused = true;
         }
         editor.onKeyDown((event) => {
-            if (new RegExp(NON_ASCII_REGEXP).test(event.code)) {
+            if (new RegExp(NON_ASCII_REGEXP).test(event.browserEvent.key)) {
                 event.preventDefault();
                 event.stopPropagation();
             }

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/text/macro-text.component.ts
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/text/macro-text.component.ts
@@ -8,9 +8,9 @@ import {
 } from '@angular/core';
 import { TextMacroAction } from 'uhk-common';
 
-import { MacroBaseComponent } from '../macro-base.component';
+import { NON_ASCII_REGEXP } from '../../../../../util';
 
-const NON_ASCII_REGEXP = /[^\x00-\x7F]/g;
+import { MacroBaseComponent } from '../macro-base.component';
 
 @Component({
     selector: 'macro-text-tab',

--- a/packages/uhk-web/src/app/util/constants.ts
+++ b/packages/uhk-web/src/app/util/constants.ts
@@ -1,0 +1,1 @@
+export const NON_ASCII_REGEXP = /[^\x00-\x7F]/g;

--- a/packages/uhk-web/src/app/util/index.ts
+++ b/packages/uhk-web/src/app/util/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export * from './find-module-by-id';
 export * from './find-new-item';
 export * from './html-helper';


### PR DESCRIPTION
Summary:
- move the `NON_ASCII_REGEXP` into a util file because, used in multiple places
- use the browser keydown event.key instead of the monaco editor code event, because the browser keydown event.key contains the ascii key code