### PR TITLE
feat: send the firmware git repo info in `agent-message-context` message

### DIFF
--- a/packages/uhk-web/src/app/store/effects/smart-macro-doc.effect.ts
+++ b/packages/uhk-web/src/app/store/effects/smart-macro-doc.effect.ts
@@ -3,12 +3,13 @@ import { Action, Store } from '@ngrx/store';
 import { Actions, Effect, ofType } from '@ngrx/effects';
 import { Observable } from 'rxjs';
 import { tap, withLatestFrom } from 'rxjs/operators';
+import { FirmwareRepoInfo } from 'uhk-common';
 
 import { SmartMacroDocRendererService } from '../../services/smart-macro-doc-renderer.service';
 import { SmartMacroDocService } from '../../services/smart-macro-doc-service';
 import * as Device from '../actions/device';
 import { ActionTypes } from '../actions/smart-macro-doc.action';
-import { AppState, getSmartMacroDocModuleIds } from '../index';
+import { AppState, getRightModuleFirmwareRepoInfo, getSmartMacroDocModuleIds } from '../index';
 
 @Injectable()
 export class SmartMacroDocEffect {
@@ -23,8 +24,8 @@ export class SmartMacroDocEffect {
         .pipe(
             ofType(ActionTypes.SmdInited, Device.ActionTypes.ModulesInfoLoaded, Device.ActionTypes.ConnectionStateChanged,
                 Device.ActionTypes.UpdateFirmwareSuccess, Device.ActionTypes.UpdateFirmwareFailed),
-            withLatestFrom(this.store.select(getSmartMacroDocModuleIds)),
-            tap(([, modules]) => this.sendMessageContext(modules))
+            withLatestFrom(this.store.select(getSmartMacroDocModuleIds), this.store.select(getRightModuleFirmwareRepoInfo)),
+            tap(([, modules, repoInfo]) => this.sendMessageContext(modules, repoInfo))
         );
 
     constructor(private actions$: Actions,
@@ -34,9 +35,10 @@ export class SmartMacroDocEffect {
 
     }
 
-    private sendMessageContext(modulesIds: Array<number>): void {
+    private sendMessageContext(modulesIds: Array<number>, firmwareRepoInfo: FirmwareRepoInfo): void {
         this.smartMacroDocService.sendMessage({
             action: 'agent-message-context',
+            firmwareRepoInfo,
             isRunningInAgent: true,
             modules: modulesIds,
             version: '1.0.0'

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -179,7 +179,7 @@ export const getHardwareModules = createSelector(runningInElectron, getStateHard
                 deviceProtocolVersion: agentVersionInfo.deviceProtocolVersion,
                 hardwareConfigVersion: agentVersionInfo.hardwareConfigVersion,
                 firmwareVersion: agentVersionInfo.firmwareVersion,
-                firmwareGitRepo: 'UltimateHackingKeyboard/firmware',
+                firmwareGitRepo: UHK_OFFICIAL_FIRMWARE_REPO,
                 firmwareGitTag: 'master',
                 moduleProtocolVersion: agentVersionInfo.moduleProtocolVersion,
                 userConfigVersion: agentVersionInfo.userConfigVersion

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -2,7 +2,7 @@ import { ActionReducerMap, createSelector, MetaReducer } from '@ngrx/store';
 import { routerReducer, RouterReducerState } from '@ngrx/router-store';
 import { storeFreeze } from 'ngrx-store-freeze';
 import { gt } from 'semver';
-import { Constants, UHK_OFFICIAL_FIRMWARE_REPO } from 'uhk-common';
+import { Constants, FirmwareRepoInfo, UHK_OFFICIAL_FIRMWARE_REPO } from 'uhk-common';
 
 import {
     ApplicationSettings,
@@ -179,6 +179,8 @@ export const getHardwareModules = createSelector(runningInElectron, getStateHard
                 deviceProtocolVersion: agentVersionInfo.deviceProtocolVersion,
                 hardwareConfigVersion: agentVersionInfo.hardwareConfigVersion,
                 firmwareVersion: agentVersionInfo.firmwareVersion,
+                firmwareGitRepo: 'UltimateHackingKeyboard/firmware',
+                firmwareGitTag: 'master',
                 moduleProtocolVersion: agentVersionInfo.moduleProtocolVersion,
                 userConfigVersion: agentVersionInfo.userConfigVersion
             }
@@ -188,6 +190,12 @@ export const getSmartMacroDocModuleIds = createSelector(getHardwareModules, (har
     return hardwareModules.moduleInfos
         .filter(moduleInfo => moduleInfo.module.id > 1)
         .map(moduleInfo => moduleInfo.module.id);
+});
+export const getRightModuleFirmwareRepoInfo = createSelector(getHardwareModules, (hardwareModules): FirmwareRepoInfo => {
+    return {
+        firmwareGitRepo: hardwareModules?.rightModuleInfo?.firmwareGitRepo || '',
+        firmwareGitTag: hardwareModules?.rightModuleInfo?.firmwareGitTag || '',
+    };
 });
 export const getBackupUserConfigurationState = createSelector(deviceState, fromDevice.getBackupUserConfigurationState);
 export const getRestoreUserConfiguration = createSelector(deviceState, fromDevice.getHasBackupUserConfiguration);

--- a/smart-macro-docs/index.html
+++ b/smart-macro-docs/index.html
@@ -556,7 +556,7 @@ Syntax is <code>set leds.fadeTimeout {timeout}</code><br>
 
 <p>Enable/disable the extended commands of the macro engine.</p>
 
-<p>There are <a href="https://github.com/UltimateHackingKeyboard/firmware/blob/master/doc-dev/user-guide.md" target="_blank">extended macro commands</a> available besides the ones mentioned here, but they're disabled by default because most of them are quite niche. These commands can be explicitly enabled via this variable, after which they can be used just like the commands featured here.</p>
+<p>There are <a :href="'https://github.com/' + firmwareRepoInfo.firmwareGitRepo + '/blob/' + firmwareRepoInfo.firmwareGitTag + '/doc-dev/user-guide.md'" target="_blank">extended macro commands</a> available besides the ones mentioned here, but they're disabled by default because most of them are quite niche. These commands can be explicitly enabled via this variable, after which they can be used just like the commands featured here.</p>
 
 <p>We plan to make most or possibly all of the extended commands directly accessible and include them in this documentation step by step after careful consideration.</p>
 

--- a/smart-macro-docs/script.mjs
+++ b/smart-macro-docs/script.mjs
@@ -223,12 +223,17 @@ const Select2 = {
     }
 };
 
+const DEFAULT_FIRMWARE_REPO_INFO = {
+    firmwareGitRepo: 'UltimateHackingKeyboard/firmware',
+    firmwareGitTag: 'master',
+};
 // Init Vue
 
 const app = createApp({
     data() {
         return {
             modules: [],
+            firmwareRepoInfo: DEFAULT_FIRMWARE_REPO_INFO,
             isRunningInAgent: false,
             moduleStrings: {
                 2: 'keycluster',
@@ -580,6 +585,7 @@ const app = createApp({
                 case 'agent-message-context': {
                     const data = event.data;
                     self.modules = data.modules;
+                    self.firmwareRepoInfo = data.firmwareRepoInfo || DEFAULT_FIRMWARE_REPO_INFO;
                     self.isRunningInAgent = data.isRunningInAgent;
                     updateWidgets();
                     break;


### PR DESCRIPTION
related firmware PR: UltimateHackingKeyboard/firmware#516

Summary:
 - send the firmware git repo of right half in `agent-message-context` message
 - in browser mode uses the master branch of UHK official firmware. It is not testable because we use a dummy smart macro doc in the web version