### PR TITLE
chore: switch from electron-notarize to @electron/notarize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "See in LICENSE",
       "devDependencies": {
+        "@electron/notarize": "1.2.3",
         "@types/command-line-args": "5.2.0",
         "@types/command-line-usage": "5.0.2",
         "@types/decompress": "4.2.4",
@@ -39,7 +40,6 @@
         "electron-debug": "1.5.0",
         "electron-devtools-installer": "2.2.3",
         "electron-log": "4.4.1",
-        "electron-notarize": "1.2.1",
         "electron-settings": "4.0.2",
         "electron-updater": "5.3.0",
         "eslint": "8.9.0",
@@ -301,6 +301,34 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-1.2.3.tgz",
+      "integrity": "sha512-9oRzT56rKh5bspk3KpAVF8lPKHYQrBnRwcgiOeR0hdilVEQmszDaAu0IPCPrwwzJN0ugNs0rRboTreHMt/6mBQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@electron/universal": {
@@ -6115,35 +6143,6 @@
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.1.tgz",
       "integrity": "sha512-nK/DwxPLtwWbggPCm27eMQhYHc3gzoZ+cokBK99diO4WsZJKrv5l44EUW8mRfWpmC8ZubnMyp6GTUIJyTc9AJA==",
       "dev": true
-    },
-    "node_modules/electron-notarize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.1.tgz",
-      "integrity": "sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==",
-      "deprecated": "Please use @electron/notarize moving forward.  There is no API change, just a package name change",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "fs-extra": "^9.0.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/electron-notarize/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/electron-osx-sign": {
       "version": "0.6.0",
@@ -15152,6 +15151,30 @@
         }
       }
     },
+    "@electron/notarize": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-1.2.3.tgz",
+      "integrity": "sha512-9oRzT56rKh5bspk3KpAVF8lPKHYQrBnRwcgiOeR0hdilVEQmszDaAu0IPCPrwwzJN0ugNs0rRboTreHMt/6mBQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
     "@electron/universal": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.2.1.tgz",
@@ -19735,30 +19758,6 @@
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.1.tgz",
       "integrity": "sha512-nK/DwxPLtwWbggPCm27eMQhYHc3gzoZ+cokBK99diO4WsZJKrv5l44EUW8mRfWpmC8ZubnMyp6GTUIJyTc9AJA==",
       "dev": true
-    },
-    "electron-notarize": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.1.tgz",
-      "integrity": "sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "fs-extra": "^9.0.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
-      }
     },
     "electron-osx-sign": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "electron-debug": "1.5.0",
     "electron-devtools-installer": "2.2.3",
     "electron-log": "4.4.1",
-    "electron-notarize": "1.2.1",
+    "@electron/notarize": "1.2.3",
     "electron-settings": "4.0.2",
     "electron-updater": "5.3.0",
     "eslint": "8.9.0",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -30,7 +30,7 @@ if (!isReleaseCommit) {
 const path = require('path');
 const builder = require("electron-builder");
 const fs = require('fs-extra');
-const { notarize } = require('electron-notarize');
+const { notarize } = require('@electron/notarize');
 
 const Platform = builder.Platform;
 const electron_build_folder = path.join(__dirname, '../packages/uhk-agent/dist');


### PR DESCRIPTION
It is the same package, just developers publish it under @electron org