### PR TITLE
fix: always update smart macro doc when macro command changing

### DIFF
--- a/packages/uhk-web/src/app/services/smart-macro-doc-service.ts
+++ b/packages/uhk-web/src/app/services/smart-macro-doc-service.ts
@@ -63,7 +63,7 @@ export class SmartMacroDocService implements OnDestroy {
     }
 
     updateCommand(command: string): void {
-        this.dispatchMacroEditorFocusEvent(command);
+        this.dispatchMacroEditorFocusEvent(command, true);
     }
 
     /**
@@ -123,13 +123,13 @@ export class SmartMacroDocService implements OnDestroy {
         });
     }
 
-    private dispatchMacroEditorFocusEvent(command = ''): void {
+    private dispatchMacroEditorFocusEvent(command = '', updateCommand = false): void {
         const message = {
             action: 'agent-message-editor-lost-focus',
             command: ''
         };
 
-        if (command) {
+        if (command || updateCommand) {
             message.action = 'agent-message-editor-got-focus';
             message.command = command;
         }


### PR DESCRIPTION
Covered case:
- click into the smart macro command input that has value
- select the whole content with CTRL + A
- press backspace. It deletes the content of the editor but the smart macro sidebar hadn't been updated.
