### PR TITLE
fix: macOS 13.3 does not fill interface property of USB Device

### DIFF
--- a/packages/uhk-usb/src/util.ts
+++ b/packages/uhk-usb/src/util.ts
@@ -5,6 +5,7 @@ import MemoryMap from 'nrf-intel-hex';
 import { Buffer, LogService, UHK_DEVICES, UhkDeviceProduct } from 'uhk-common';
 
 import { Constants, UsbCommand } from './constants.js';
+import isOsProvideUsbInterface from './utils/is-os-provide-usb-interface.js';
 
 export const snooze = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -104,7 +105,10 @@ export async function retry(command: Function, maxTry = 3, logService?: LogServi
 export const isUhkZeroInterface = (dev: Device): boolean => {
     return UHK_DEVICES.some(device => dev.vendorId === device.vendorId &&
         dev.productId === device.keyboardPid &&
-        dev.interface === 0
+        ((dev.usagePage === 128 && dev.usage === 129) || // Old firmware
+            (dev.usagePage === (0xFF00 | 0x00) && dev.usage === 0x01) || // New firmware
+            (dev.interface === 0 && isOsProvideUsbInterface())
+        )
     );
 };
 

--- a/packages/uhk-usb/src/utils/is-os-provide-usb-interface.ts
+++ b/packages/uhk-usb/src/utils/is-os-provide-usb-interface.ts
@@ -1,0 +1,18 @@
+import {platform, release} from 'os';
+import semver from 'semver';
+
+let value: boolean | null = null;
+
+/**
+ * From macOS 13.3 (Darwin Kernel Version 22.4.0) the interface property of USB device is not provided by the OS.
+ */
+export default function isOsProvideUsbInterface(): boolean {
+    if (value !== null) {
+        return value;
+    }
+
+    value = platform() !== 'darwin' ||
+        (platform() === 'darwin' && semver.lt(release(), '22.4.0'));
+
+    return value;
+}


### PR DESCRIPTION
closes #1971