### PR TITLE
fix: show scancode icons in macro item header

### DIFF
--- a/packages/uhk-web/src/app/components/macro/item/macro-item.component.html
+++ b/packages/uhk-web/src/app/components/macro/item/macro-item.component.html
@@ -6,7 +6,10 @@
                  aria-hidden="true"></fa-icon>
         <div class="action--item--wrap" [class.pointer]="editable" (click)="editAction()">
             <icon [name]="iconName" class="align-items-top"></icon>
-            <div class="action--title">{{ title }}</div>
+            <div class="action--title">
+                {{ title }}
+                <svg-sprite-image *ngIf="titleIcon" [icon]="titleIcon"></svg-sprite-image>
+            </div>
             <icon *ngIf="editable && macroAction && !editing" name="pencil" class="align-items-top"></icon>
         </div>
         <icon *ngIf="deletable" name="trash" (click)="deleteAction()" class="align-items-top"></icon>

--- a/packages/uhk-web/src/app/components/macro/item/macro-item.component.scss
+++ b/packages/uhk-web/src/app/components/macro/item/macro-item.component.scss
@@ -103,3 +103,7 @@
     border-radius: 0;
     border: none;
 }
+
+svg-sprite-image {
+    margin-left: 0.25em;
+}

--- a/packages/uhk-web/src/app/components/macro/item/macro-item.component.ts
+++ b/packages/uhk-web/src/app/components/macro/item/macro-item.component.ts
@@ -80,6 +80,7 @@ export class MacroItemComponent implements OnInit, OnChanges {
     @Output() selected = new EventEmitter<SelectedMacroItem>();
 
     title: string;
+    titleIcon: string;
     iconName: string;
     newItem: boolean = false;
     faGripLinesVertical = faGripLinesVertical;
@@ -179,6 +180,7 @@ export class MacroItemComponent implements OnInit, OnChanges {
     }
 
     private setKeyActionContent(action: KeyMacroAction): void {
+        this.titleIcon = undefined;
         if (!action.hasScancode() && !action.hasModifiers()) {
             this.title = 'Invalid keypress';
             return;
@@ -210,9 +212,14 @@ export class MacroItemComponent implements OnInit, OnChanges {
         }
 
         if (action.hasScancode()) {
-            const scancode: string = (this.mapper.scanCodeToText(action.scancode, action.type) || ['Unknown']).join(' ');
+            const scancode = this.mapper.scanCodeToText(action.scancode, action.type) || ['Unknown'];
             if (scancode) {
-                texts.push(scancode);
+                if (scancode.length > 1 && scancode[1].startsWith('icon')) {
+                    texts.push(scancode[0]);
+                    this.titleIcon = this.mapper.getIcon(scancode[1]);
+                } else {
+                    texts.push(scancode.join(' '));
+                }
             }
         }
 

--- a/packages/uhk-web/src/app/components/svg/svg-sprite-image.ts
+++ b/packages/uhk-web/src/app/components/svg/svg-sprite-image.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+    selector: 'svg-sprite-image',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `
+        <svg viewBox="0 0 16 16" height="1em" preserveAspectRatio="xMidYMin">
+            <svg:use [attr.xlink:href]="icon">
+            </svg:use>
+        </svg>
+    `,
+    styles: [`
+        :host {
+            display: inline;
+        }
+
+        svg {
+            margin-top:auto;
+            margin-bottom:auto;
+            fill: currentColor;
+        }
+    `]
+})
+export class SvgSpriteImage {
+    @Input() icon: string;
+}

--- a/packages/uhk-web/src/app/shared.module.ts
+++ b/packages/uhk-web/src/app/shared.module.ts
@@ -82,6 +82,7 @@ import {
     SvgTwoLineTextKeyComponent
 } from './components/svg/keys';
 import { SvgModuleComponent } from './components/svg/module';
+import { SvgSpriteImage } from './components/svg/svg-sprite-image';
 import { SvgKeyboardWrapComponent } from './components/svg/wrap';
 import { appRoutingProviders, routing } from './app.routes';
 
@@ -209,6 +210,7 @@ import appInitFactory from './services/app-init-factory';
         AboutComponent,
         ContributorBadgeComponent,
         SettingsComponent,
+        SvgSpriteImage,
         KeyboardSliderComponent,
         CancelableDirective,
         SafeStylePipe,


### PR DESCRIPTION
closes: #2018

Normal line
<img width="1256" alt="Screenshot 2023-06-11 at 10 23 18" src="https://github.com/UltimateHackingKeyboard/agent/assets/496775/3c0e1c6a-98bc-4e1d-9e0a-7f8332cc4884">

Hovered line
<img width="1297" alt="Screenshot 2023-06-11 at 10 23 27" src="https://github.com/UltimateHackingKeyboard/agent/assets/496775/ad88d039-e0b1-426c-aab3-9fac868ada83">
