### PR TITLE
fix: suggestion widget visibility, bump monaco-editor 0.41.0 => 0.44.0

### DIFF
--- a/packages/uhk-web/package-lock.json
+++ b/packages/uhk-web/package-lock.json
@@ -60,7 +60,7 @@
         "karma-coverage": "2.1.0",
         "karma-jasmine": "4.0.1",
         "karma-jasmine-html-reporter": "1.7.0",
-        "monaco-editor": "0.41.0",
+        "monaco-editor": "0.44.0",
         "ng2-dragula": "2.1.1",
         "ng2-nouislider": "1.8.3",
         "ngrx-store-freeze": "0.2.4",
@@ -11284,9 +11284,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.41.0.tgz",
-      "integrity": "sha512-1o4olnZJsiLmv5pwLEAmzHTE/5geLKQ07BrGxlF4Ri/AXAc2yyDGZwHjiTqD8D/ROKUZmwMA28A+yEowLNOEcA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
+      "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==",
       "dev": true
     },
     "node_modules/ms": {

--- a/packages/uhk-web/package.json
+++ b/packages/uhk-web/package.json
@@ -67,7 +67,7 @@
     "karma-coverage": "2.1.0",
     "karma-jasmine": "4.0.1",
     "karma-jasmine-html-reporter": "1.7.0",
-    "monaco-editor": "0.41.0",
+    "monaco-editor": "0.44.0",
     "ng2-dragula": "2.1.1",
     "ng2-nouislider": "1.8.3",
     "ngrx-store-freeze": "0.2.4",

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command-editor.component.scss
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command-editor.component.scss
@@ -8,6 +8,10 @@
     &.readonly {
         max-height: fit-content;
     }
+
+    ::ng-deep .editor-container {
+        overflow: visible;
+    }
 }
 
 :host(.active) {

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command-editor.component.ts
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command-editor.component.ts
@@ -23,7 +23,7 @@ import { SelectedMacroActionId } from '../../../../../models';
 import { SmartMacroDocCommandAction, SmartMacroDocService } from '../../../../../services/smart-macro-doc-service';
 import { hasNonAsciiCharacters, NON_ASCII_REGEXP } from '../../../../../util';
 
-const MONACO_EDITOR_LINE_HEIGHT_OPTION = 65;
+const MONACO_EDITOR_LINE_HEIGHT_OPTION = 66;
 const MONACO_EDITOR_LF_END_OF_LINE_OPTION = 0;
 const MACRO_CHANGE_DEBOUNCE_TIME = 250;
 


### PR DESCRIPTION
If user edited the last line then the suggestion widget was not visible.