### PR TITLE
fix: color of text-muted css selector

### DIFF
--- a/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.html
+++ b/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.html
@@ -16,12 +16,12 @@
                     </span>
                     {{ state.moduleName }}
                     <span *ngIf="state.firmwareUpgradeSupported">firmware:
-                        <span *ngIf="state.gitRepo" [class.text-muted]="state.isOfficialFirmware">{{ state.gitRepo }}:</span>
+                        <span *ngIf="state.gitRepo" [class.text-body-secondary]="state.isOfficialFirmware">{{ state.gitRepo }}:</span>
                         <span [class.text-dotted]="state.tooltip"
                               [ngbTooltip]="state.tooltip"
                               tooltipClass="tooltip-firmware-version"
                         >{{ state.currentFirmwareVersion }}</span>
-                        <span *ngIf="state.gitTag" [class.text-muted]="state.isOfficialFirmware">{{ gitTagText(state.currentFirmwareVersion, state.gitTag) }}</span>
+                        <span *ngIf="state.gitTag" [class.text-body-secondary]="state.isOfficialFirmware">{{ gitTagText(state.currentFirmwareVersion, state.gitTag) }}</span>
                         <span *ngIf="state.newFirmwareVersion && state.currentFirmwareVersion !== state.newFirmwareVersion">
                             <fa-icon [icon]="faLongArrowAltRight"></fa-icon> {{ state.newFirmwareVersion }}
                         </span>

--- a/packages/uhk-web/src/app/components/popover/tab/keymap/keymap-tab.component.html
+++ b/packages/uhk-web/src/app/components/popover/tab/keymap/keymap-tab.component.html
@@ -13,7 +13,7 @@
                     (select)="onChange($event)">
 
             <ng-template ngx-select-option let-option>
-                <div [ngClass]="{'text-muted': option.disabled}">
+                <div [ngClass]="{'text-body-secondary': option.disabled}">
                     <span [ngClass]="{'indent-dropdown-item':option.data.id !== '-1'}">
                             <span>{{ option.text }}</span>
                             <span class="scancode--searchterm">

--- a/packages/uhk-web/src/styles/themes/_dark.scss
+++ b/packages/uhk-web/src/styles/themes/_dark.scss
@@ -61,6 +61,7 @@ $input-focus-border-color: tint-color($component-active-bg, 25%) !default;
 
 :root,
 .theme-dark {
+    --bs-secondary-color: #{$secondary} !important;
     --bs-list-group-bg: #{$input-bg};
 
     --color-btn-danger-text: #{$white};

--- a/packages/uhk-web/src/styles/themes/_dark.scss
+++ b/packages/uhk-web/src/styles/themes/_dark.scss
@@ -61,7 +61,7 @@ $input-focus-border-color: tint-color($component-active-bg, 25%) !default;
 
 :root,
 .theme-dark {
-    --bs-secondary-color: #{$secondary} !important;
+    --bs-secondary-color: #{$secondary} !important; /* stylelint-disable-line declaration-no-important */
     --bs-list-group-bg: #{$input-bg};
 
     --color-btn-danger-text: #{$white};


### PR DESCRIPTION
closes: #2149

Summary:
- tried to follow the bootstrap 5 dark style. Because in the future we would like to switch to BS dark mode instead of custom dark mode.
- use `text-body-secondary` as successor `text-muted`
- `--bs-secondary-color` use the `$secondary` color in dark mode

Also fixing the keymap selector of the `popover` when the list item keymap equal to the currently selected keymap.

Before:
<img width="603" alt="Screenshot 2024-01-07 at 14 59 37" src="https://github.com/UltimateHackingKeyboard/agent/assets/496775/1b1af62d-caf3-4376-b3d3-3f3fdc21b43c">

After:
<img width="597" alt="Screenshot 2024-01-07 at 15 02 10" src="https://github.com/UltimateHackingKeyboard/agent/assets/496775/85fbeb90-455f-46bc-812a-3666b69ccb78">
