### PR TITLE
fix: align CircleTooltip to top if there not enough space at bottom

### DIFF
--- a/packages/uhk-web/src/app/components/circle-tooltip/circle-tooltip.component.ts
+++ b/packages/uhk-web/src/app/components/circle-tooltip/circle-tooltip.component.ts
@@ -8,7 +8,7 @@ import { PlacementArray } from '@ng-bootstrap/ng-bootstrap/util/positioning';
     templateUrl: './circle-tooltip.component.html',
 })
 export default class CircleTooltipComponent {
-    @Input() placement: PlacementArray = 'bottom';
+    @Input() placement: PlacementArray = ['bottom', 'top'];
     @Input() tooltip: string | TemplateRef<any> | null | undefined;
     @Input() width: number | null | undefined;
 


### PR DESCRIPTION
The CircleTooltip component currently used only on the new Typings behaviour and Module config pages.
In the future, we will use it everywhere.

closes: #2205