### PR TITLE
fix: don't hide the smart macro editor autocomplete popup

### DIFF
--- a/packages/uhk-web/src/app/components/device/led-settings/led-settings.component.html
+++ b/packages/uhk-web/src/app/components/device/led-settings/led-settings.component.html
@@ -3,7 +3,7 @@
     <span>LED settings</span>
 </h1>
 
-<h3 class="mt-4">LED brightness</h3>
+<h3 class="pt-3">LED brightness</h3>
 
 <div class="row">
     <div class="col-12 col-lg-4">
@@ -40,7 +40,7 @@
     </div>
 </div>
 
-<h3 class="mt-4">Backlighting mode</h3>
+<h3 class="pt-4">Backlighting mode</h3>
 
 <div class="backlighting-mode-container">
     <div *ngFor="let option of backlightingOptions; let index = index" class="form-check">
@@ -54,7 +54,7 @@
     </div>
 </div>
 
-<h3 class="mt-4">Functional backlighting colors</h3>
+<h3 class="pt-4">Functional backlighting colors</h3>
 
 <div class="functional-backlight-color-container">
     <functional-backlight-color [label]="'None'" [color]="backlightingNoneActionColor"
@@ -75,7 +75,7 @@
                                 (colorChanged)="onSetRgbValue('backlightingMacroColor', $event)"></functional-backlight-color>
 </div>
 
-<h3 class="mt-4">LED fade timeout</h3>
+<h3 class="pt-4">LED fade timeout</h3>
 
 <div class="fade-timeout-container">
     <input

--- a/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.scss
+++ b/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.scss
@@ -33,7 +33,6 @@
 }
 
 .macro-container {
-    overflow: auto;
     padding-right: math.div($grid-gutter-width, 2);
 }
 

--- a/packages/uhk-web/src/styles/_global.scss
+++ b/packages/uhk-web/src/styles/_global.scss
@@ -74,7 +74,7 @@ ul.no-indent {
 }
 
 .h1, .h2, .h3, h1, h2, h3 {
-    margin-top: 10px;
+    padding-top: 10px;
 }
 
 input {

--- a/packages/uhk-web/src/styles/_table.scss
+++ b/packages/uhk-web/src/styles/_table.scss
@@ -13,7 +13,7 @@ table.settings {
                 width: 50%;
 
                 h3.margin-top {
-                    margin-top: 1em;
+                    padding-top: 1em;
                 }
 
                 .form-check {


### PR DESCRIPTION
Had to refactor h1 header to use padding instead of margin to remove extra scrollbars of macro page.

closes #2172