### PR TITLE
fix: tooltip positioning

### DIFF
--- a/packages/uhk-web/src/app/app.component.ts
+++ b/packages/uhk-web/src/app/app.component.ts
@@ -1,8 +1,6 @@
 import { Component, HostListener, OnDestroy, ChangeDetectorRef, ViewChild } from '@angular/core';
 import { ActivatedRoute, Event, NavigationEnd, Router } from '@angular/router';
 import { animate, style, transition, trigger } from '@angular/animations';
-import { offset as offsetModifier } from '@popperjs/core';
-import { NgbTooltipConfig } from '@ng-bootstrap/ng-bootstrap';
 import { IOutputData } from 'angular-split';
 import { Observable, Subscription } from 'rxjs';
 import { Action, Store } from '@ngrx/store';
@@ -88,7 +86,6 @@ import { SecondSideMenuContainerComponent } from './components/side-menu';
             ])
         ])
     ],
-    providers: [NgbTooltipConfig]
 })
 export class MainAppComponent implements OnDestroy {
     @ViewChild(SecondSideMenuContainerComponent) secondarySideMenuContainer: SecondSideMenuContainerComponent;
@@ -121,8 +118,7 @@ export class MainAppComponent implements OnDestroy {
     constructor(private store: Store<AppState>,
                 private route: ActivatedRoute,
                 private router: Router,
-                private cdRef: ChangeDetectorRef,
-                private ngTooltipConfig: NgbTooltipConfig) {
+                private cdRef: ChangeDetectorRef) {
         this.errorPanelHeightSubscription = store.select(getErrorPanelHeight)
             .subscribe(height => {
                 this.splitSizes = {
@@ -180,24 +176,6 @@ export class MainAppComponent implements OnDestroy {
                 this.statusBuffer = data;
                 this.cdRef.markForCheck();
             });
-
-        this.ngTooltipConfig.popperOptions = (options) => {
-            const newOptions = {
-                ...options,
-                modifiers: [
-                    offsetModifier,
-                    ...(options.modifiers || []),
-                    {
-                        name: 'offset',
-                        options: {
-                            offset: () => ([0, 6]),
-                        },
-                    },
-                ],
-            };
-
-            return newOptions;
-        };
     }
 
     ngOnDestroy(): void {

--- a/packages/uhk-web/src/app/components/agent/settings/settings.component.html
+++ b/packages/uhk-web/src/app/components/agent/settings/settings.component.html
@@ -46,12 +46,11 @@
             bindLabel="text"
             bindValue="id"
         />
-        <icon *ngIf="isLinux$ | async"
-              name="question-circle"
-              class="ms-2"
-              [ngbTooltip]="systemThemeTooltip"
-              tooltipClass="tooltip-system-theme"
-              placement="bottom"></icon>
+        <circle-tooltip
+            *ngIf="isLinux$ | async"
+            [tooltip]="systemThemeTooltip"
+            width="300"
+        />
     </div>
 </div>
 

--- a/packages/uhk-web/src/app/components/circle-tooltip/circle-tooltip.component.html
+++ b/packages/uhk-web/src/app/components/circle-tooltip/circle-tooltip.component.html
@@ -1,4 +1,6 @@
 <fa-icon [icon]="faQuestionCircle"
          [ngbTooltip]="tooltip"
+         [container]="container"
          [placement]="placement"
+         [tooltipClass]="tooltipClass"
 ></fa-icon>

--- a/packages/uhk-web/src/app/components/circle-tooltip/circle-tooltip.component.ts
+++ b/packages/uhk-web/src/app/components/circle-tooltip/circle-tooltip.component.ts
@@ -8,8 +8,10 @@ import { PlacementArray } from '@ng-bootstrap/ng-bootstrap/util/positioning';
     templateUrl: './circle-tooltip.component.html',
 })
 export default class CircleTooltipComponent {
+    @Input() container: string | null | undefined;
     @Input() placement: PlacementArray = ['bottom', 'top'];
     @Input() tooltip: string | TemplateRef<any> | null | undefined;
+    @Input() tooltipClass: string | null | undefined;
     @Input() width: number | null | undefined;
 
     readonly faQuestionCircle = faQuestionCircle;

--- a/packages/uhk-web/src/app/components/layers/layers.component.html
+++ b/packages/uhk-web/src/app/components/layers/layers.component.html
@@ -78,13 +78,5 @@
                 <fa-icon [icon]="faTrash"></fa-icon>
             </button>
         </div>
-<!--        <ng-template #colorPaletteTooltip>
-            <p>TODO: @Laci</p>
-        </ng-template>
-        <icon name="question-circle"
-              [ngbTooltip]="colorPaletteTooltip"
-              placement="bottom"></icon>
--->
-
     </div>
 </div>

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command.component.html
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command.component.html
@@ -2,11 +2,10 @@
     <div class="col-12">
         <h4>
             Macro commands
-            <icon name="question-circle"
-                [ngbTooltip]="macroContentTooltip"
-                tooltipClass="tooltip-macro-text"
-                placement="bottom">
-            </icon>
+            <circle-tooltip
+                [tooltip]="macroContentTooltip"
+                width="350"
+            />
             <ng-template #macroContentTooltip>
                 Open the <strong>Smart macro reference</strong> tab on the right edge to learn more.
             </ng-template>

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command.component.scss
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/command/macro-command.component.scss
@@ -4,8 +4,7 @@
     padding-left: 5px;
 }
 
-icon {
-    display: inline;
+circle-tooltip {
     font-size: 0.875rem;
 }
 

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/text/macro-text.component.html
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/text/macro-text.component.html
@@ -5,13 +5,11 @@
             <a class="btn btn-padding-0"
             href="https://ultimatehackingkeyboard.com/blog/2018/06/23/how-can-i-type-accented-characters-with-my-uhk"
             externalUrl>
-                <icon name="question-circle"
-                    ngbTooltip="The text below is translated to scancodes via en-US mapping.
+                <circle-tooltip
+                    tooltip="The text below is translated to scancodes via en-US mapping.
                     Output will differ correspondingly if your computer's keymap differs from en-US mapping.
                     Click to learn more."
-                    tooltipClass="tooltip-macro-text"
-                    placement="bottom">
-                </icon>
+                />
             </a>
         </h4>
         <textarea #macroTextInput

--- a/packages/uhk-web/src/app/components/popover/popover.component.html
+++ b/packages/uhk-web/src/app/components/popover/popover.component.html
@@ -95,10 +95,10 @@
                     </ul>
                 </ng-template>
                 <div class="d-inline-block">
-                    <icon name="question-circle"
-                        [ngbTooltip]="remapTooltip"
+                    <circle-tooltip
+                        [tooltip]="remapTooltip"
                         tooltipClass="tooltip-nowrap"
-                        placement="bottom"></icon>
+                    />
                 </div>
             </form>
         </div>

--- a/packages/uhk-web/src/app/components/popover/tab/keypress/keypress-tab.component.html
+++ b/packages/uhk-web/src/app/components/popover/tab/keypress/keypress-tab.component.html
@@ -36,11 +36,10 @@
     <a class="btn btn-padding-0 mb-2"
        href="https://ultimatehackingkeyboard.com/blog/2018/06/23/how-can-i-type-accented-characters-with-my-uhk"
        externalUrl>
-        <icon name="question-circle"
-              [ngbTooltip]="scanCodeTooltip"
-              tooltipClass="tooltip-scancode"
-              container="body"
-              placement="bottom"></icon>
+        <circle-tooltip
+            [tooltip]="scanCodeTooltip"
+            width="330"
+        />
     </a>
     <capture-keystroke-button (capture)="onKeysCapture($event)" tabindex="0" class="mb-2"></capture-keystroke-button>
 </div>
@@ -70,11 +69,10 @@
         </div>
 
         <span class="mt-1">
-            <icon name="question-circle"
-                  ngbTooltip="The selected modifiers will be added to the scancode emitted by this key, thus mapping it to scancode + modifier key combination. For more complex needs, you can use a macro."
-                  tooltipClass="tooltip-modifier"
-                  container="body"
-                  placement="bottom"></icon>
+            <circle-tooltip
+                tooltip="The selected modifiers will be added to the scancode emitted by this key, thus mapping it to scancode + modifier key combination. For more complex needs, you can use a macro."
+                width="370"
+            />
         </span>
     </div>
 
@@ -111,11 +109,10 @@
         <p class="text-start mb-1">The secondary role can be any layer or modifier.</p>
     </ng-template>
     <span class="mt-1">
-        <icon name="question-circle"
-              [ngbTooltip]="secondaryRoleTooltip"
-              tooltipClass="tooltip-secondary-role"
-              container="body"
-              placement="bottom"></icon>
+        <circle-tooltip
+            [tooltip]="secondaryRoleTooltip"
+            width="620"
+        />
     </span>
 </div>
 

--- a/packages/uhk-web/src/app/components/popover/tab/keypress/keypress-tab.component.scss
+++ b/packages/uhk-web/src/app/components/popover/tab/keypress/keypress-tab.component.scss
@@ -17,7 +17,7 @@
             margin-right: 0.6em;
         }
 
-        icon {
+        circle-tooltip {
             margin-left: 0.6em;
             margin-right: 0.6em;
         };
@@ -37,7 +37,7 @@
             margin-right: 4px;
         }
 
-        icon {
+        circle-tooltip {
             margin-left: 0.6em;
         };
     }
@@ -57,7 +57,7 @@
             width: 135px;
         }
 
-        icon {
+        circle-tooltip {
             margin-left: 0.6em;
         }
     }

--- a/packages/uhk-web/src/app/components/slider-wrapper/slider-wrapper.component.html
+++ b/packages/uhk-web/src/app/components/slider-wrapper/slider-wrapper.component.html
@@ -3,10 +3,10 @@
     <ng-template #htmlTooltipTemplate>
         <div [innerHTML]="htmlTooltip()"></div>
     </ng-template>
-    <icon name="question-circle"
-            [ngbTooltip]="htmlTooltipTemplate"
-            placement="bottom"
-            *ngIf="tooltip"></icon>
+    <circle-tooltip
+        *ngIf="tooltip"
+        [tooltip]="htmlTooltipTemplate"
+    />
 </label>
 <div class="slider-wrapper">
     <div class="slider-container">

--- a/packages/uhk-web/src/app/components/slider-wrapper/slider-wrapper.component.scss
+++ b/packages/uhk-web/src/app/components/slider-wrapper/slider-wrapper.component.scss
@@ -4,10 +4,6 @@ $side-value-width: 80px;
     label {
         display: block;
         font-weight: normal;
-
-        icon {
-            display: inline-block;
-        }
     }
 
     .slider-wrapper {

--- a/packages/uhk-web/src/styles/_global.scss
+++ b/packages/uhk-web/src/styles/_global.scss
@@ -264,30 +264,9 @@ kbd {
     max-width: 100%;
 }
 
-.tooltip-scancode .tooltip-inner {
-    width: 330px;
-    max-width: 330px;
-}
-
-.tooltip-modifier .tooltip-inner {
-    width: 370px;
-    max-width: 370px;
-}
-
-.tooltip-secondary-role .tooltip-inner {
-    width: 620px;
-    max-width: 620px;
-}
-
-.tooltip-firmware-version .tooltip-inner,
-.tooltip-macro-text .tooltip-inner {
+.tooltip-firmware-version .tooltip-inner {
     width: 350px;
     max-width: 350px;
-}
-
-.tooltip-system-theme .tooltip-inner {
-    width: 300px;
-    max-width: 300px;
 }
 
 mwl-confirmation-popover-window {


### PR DESCRIPTION
closes: #2260

This PR replaces all old circle icon with tooltip with the `circle-tooltip` component. This component tries to show the tooltip at bottom of the icon but if there is not enough place then render at the top of the icon. The `circle-tooltip` also supports to set custom tooltip width so we don't need custom css classes.