### PR TITLE
fix: "Double tap to lock layer timeout" tooltip on the typing behaviour page

### DIFF
--- a/packages/uhk-web/src/app/components/device/typing-behaviour-page/typing-behaviour-page.html
+++ b/packages/uhk-web/src/app/components/device/typing-behaviour-page/typing-behaviour-page.html
@@ -176,7 +176,7 @@
             </tr>
             <tr class="separator">
                 <td>Double tap to lock layer timeout
-                    <circle-tooltip tooltip="Configures double tap time behavior for the secondary roles."
+                    <circle-tooltip tooltip="Double tap to lock layer timeout configures doubletap timeout for layer switchers, and also for the `ifDoubletap` macro condition."
                                     width="250"/>
                 </td>
                 <td>


### PR DESCRIPTION
closes #2261