### PR TITLE
fix: set default value of upgradeType on firmware page

### DIFF
--- a/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.ts
+++ b/packages/uhk-web/src/app/components/device/firmware/device-firmware.component.ts
@@ -40,7 +40,7 @@ export class DeviceFirmwareComponent implements OnDestroy {
     firmwareUpgradeFailed: boolean;
     firmwareUpgradeFailReasons = FirmwareUpgradeFailReason;
     firmwareUpgradeSuccess: boolean;
-    upgradeType: string;
+    upgradeType = 'Firmware';
 
     @ViewChild(XtermComponent, { static: false }) xtermRef: XtermComponent;
 


### PR DESCRIPTION
closes #2259

The firmware upgrade can be started from other places than the firmware page. In this case the upgrade type field did not have value.