### PR TITLE
chore: remove unused noUiSlider pips

### DIFF
--- a/packages/uhk-web/src/app/components/device/led-settings/led-settings.component.html
+++ b/packages/uhk-web/src/app/components/device/led-settings/led-settings.component.html
@@ -12,7 +12,6 @@
             [min]="0"
             [max]="255"
             [step]="1"
-            [pips]="sliderPips"
             [(ngModel)]="iconsAndLayerTextsBrightness"
             (ngModelChange)="onSetPropertyValue('iconsAndLayerTextsBrightness', $event)"></slider-wrapper>
     </div>
@@ -23,7 +22,6 @@
             [min]="0"
             [max]="255"
             [step]="1"
-            [pips]="sliderPips"
             [(ngModel)]="alphanumericSegmentsBrightness"
             (ngModelChange)="onSetPropertyValue('alphanumericSegmentsBrightness', $event)"></slider-wrapper>
     </div>
@@ -34,7 +32,6 @@
             [min]="0"
             [max]="255"
             [step]="1"
-            [pips]="sliderPips"
             [(ngModel)]="keyBacklightBrightness"
             (ngModelChange)="onSetPropertyValue('keyBacklightBrightness', $event)"></slider-wrapper>
     </div>

--- a/packages/uhk-web/src/app/components/device/led-settings/led-settings.component.ts
+++ b/packages/uhk-web/src/app/components/device/led-settings/led-settings.component.ts
@@ -6,7 +6,6 @@ import {
     SetUserConfigurationRgbValueAction,
     SetUserConfigurationValueAction
 } from '../../../store/actions/user-config';
-import { SliderPips } from '../../slider-wrapper/slider-wrapper.component';
 import { Observable, Subscription } from 'rxjs';
 import { faSlidersH } from '@fortawesome/free-solid-svg-icons';
 import { BacklightingMode, RgbColorInterface, UserConfiguration } from 'uhk-common';
@@ -36,12 +35,6 @@ export class LEDSettingsComponent implements OnInit, OnDestroy {
     public iconsAndLayerTextsBrightness: number = 0;
     public alphanumericSegmentsBrightness: number = 0;
     public keyBacklightBrightness: number = 0;
-    public sliderPips: SliderPips = {
-        mode: 'positions',
-        values: [0, 50, 100],
-        density: 6,
-        stepped: true
-    };
     faSlidersH = faSlidersH;
 
     private userConfig$: Observable<UserConfiguration>;

--- a/packages/uhk-web/src/app/components/device/mouse-speed/mouse-speed.component.html
+++ b/packages/uhk-web/src/app/components/device/mouse-speed/mouse-speed.component.html
@@ -30,7 +30,6 @@
                 [min]="moveSettings.min"
                 [max]="moveSettings.max"
                 [step]="moveSettings.step"
-                [pips]="sliderPips"
                 valueUnit="px/s"
                 [(ngModel)]="mouseMoveInitialSpeed"
                 (ngModelChange)="onSetMouseMovePropertyValue('mouseMoveInitialSpeed', $event)"/>
@@ -41,7 +40,6 @@
                 [min]="moveSettings.min"
                 [max]="moveSettings.max"
                 [step]="moveSettings.step"
-                [pips]="sliderPips"
                 valueUnit="px/s"
                 [(ngModel)]="mouseMoveBaseSpeed"
                 (ngModelChange)="onSetMouseMovePropertyValue('mouseMoveBaseSpeed', $event)"/>
@@ -52,7 +50,6 @@
                 [min]="moveSettings.min"
                 [max]="moveSettings.max"
                 [step]="moveSettings.step"
-                [pips]="sliderPips"
                 valueUnit="px/s"
                 [(ngModel)]="mouseMoveAcceleration"
                 (ngModelChange)="onSetMouseMovePropertyValue('mouseMoveAcceleration', $event)"/>
@@ -63,7 +60,6 @@
                 [min]="moveSettings.min"
                 [max]="moveSettings.max"
                 [step]="moveSettings.step"
-                [pips]="sliderPips"
                 valueUnit="px/s"
                 [(ngModel)]="mouseMoveDeceleratedSpeed"
                 (ngModelChange)="onSetMouseMovePropertyValue('mouseMoveDeceleratedSpeed', $event)"/>
@@ -74,7 +70,6 @@
                 [min]="moveSettings.min"
                 [max]="moveSettings.max"
                 [step]="moveSettings.step"
-                [pips]="sliderPips"
                 valueUnit="px/s"
                 [(ngModel)]="mouseMoveAcceleratedSpeed"
                 (ngModelChange)="onSetMouseMovePropertyValue('mouseMoveAcceleratedSpeed', $event)"/>
@@ -85,7 +80,6 @@
                 [min]="0.1"
                 [max]="10"
                 [step]="0.1"
-                [pips]="sliderPips"
                 valueUnit=""
                 [(ngModel)]="mouseMoveAxisSkew"
                 (ngModelChange)="onSetPropertyValue('mouseMoveAxisSkew', $event)"/>
@@ -113,7 +107,6 @@
                 [min]="scrollSettings.min"
                 [max]="scrollSettings.max"
                 [step]="scrollSettings.step"
-                [pips]="sliderPips"
                 valueUnit="pulse/s"
                 [(ngModel)]="mouseScrollInitialSpeed"
                 (ngModelChange)="onSetPropertyValue('mouseScrollInitialSpeed', $event)"/>
@@ -124,7 +117,6 @@
                 [min]="scrollSettings.min"
                 [max]="scrollSettings.max"
                 [step]="scrollSettings.step"
-                [pips]="sliderPips"
                 valueUnit="pulse/s"
                 [(ngModel)]="mouseScrollBaseSpeed"
                 (ngModelChange)="onSetPropertyValue('mouseScrollBaseSpeed', $event)"/>
@@ -135,7 +127,6 @@
                 [min]="scrollSettings.min"
                 [max]="scrollSettings.max"
                 [step]="scrollSettings.step"
-                [pips]="sliderPips"
                 valueUnit="pulse/s"
                 [(ngModel)]="mouseScrollAcceleration"
                 (ngModelChange)="onSetPropertyValue('mouseScrollAcceleration', $event)"/>
@@ -146,7 +137,6 @@
                 [min]="scrollSettings.min"
                 [max]="scrollSettings.max"
                 [step]="scrollSettings.step"
-                [pips]="sliderPips"
                 valueUnit="pulse/s"
                 [(ngModel)]="mouseScrollDeceleratedSpeed"
                 (ngModelChange)="onSetPropertyValue('mouseScrollDeceleratedSpeed', $event)"/>
@@ -157,7 +147,6 @@
                 [min]="scrollSettings.min"
                 [max]="scrollSettings.max"
                 [step]="scrollSettings.step"
-                [pips]="sliderPips"
                 valueUnit="pulse/s"
                 [(ngModel)]="mouseScrollAcceleratedSpeed"
                 (ngModelChange)="onSetPropertyValue('mouseScrollAcceleratedSpeed', $event)"/>
@@ -168,7 +157,6 @@
                 [min]="0.1"
                 [max]="10"
                 [step]="0.1"
-                [pips]="sliderPips"
                 valueUnit=""
                 [(ngModel)]="mouseScrollAxisSkew"
                 (ngModelChange)="onSetPropertyValue('mouseScrollAxisSkew', $event)"/>

--- a/packages/uhk-web/src/app/components/device/mouse-speed/mouse-speed.component.ts
+++ b/packages/uhk-web/src/app/components/device/mouse-speed/mouse-speed.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AppState, getUserConfiguration } from '../../../store';
 import { SetUserConfigurationValueAction } from '../../../store/actions/user-config';
-import { SliderPips, SliderProps } from '../../slider-wrapper/slider-wrapper.component';
+import { SliderProps } from '../../slider-wrapper/slider-wrapper.component';
 import { Subscription } from 'rxjs';
 import { faSlidersH } from '@fortawesome/free-solid-svg-icons';
 import { ResetPcMouseSpeedSettingsAction, ResetMacMouseSpeedSettingsAction } from '../../../store/actions/device';
@@ -33,13 +33,6 @@ export class MouseSpeedComponent implements OnInit, OnDestroy {
     mouseScrollAxisSkew: number;
 
     diagonalSpeedCompensation: boolean;
-
-    public sliderPips: SliderPips = {
-        mode: 'positions',
-        values: [0, 50, 100],
-        density: 6,
-        stepped: true
-    };
 
     public moveSettings: SliderProps = {
         min: MOUSE_MOVE_VALUE_MULTIPLIER,


### PR DESCRIPTION
In the #1707 PR we removed the visibility of the pips from the sliders, but we did not deleted the pips properties. In the #2275 we have to use pips, so in this PR I just remove the old unused pip definitions