### PR TITLE
fix: show legacy user config history when new device connected

### DIFF
--- a/packages/uhk-web/src/app/components/user-configuration-history/user-configuration-history.component.html
+++ b/packages/uhk-web/src/app/components/user-configuration-history/user-configuration-history.component.html
@@ -28,7 +28,7 @@
         </ul>
 
         <ul class="list-unstyled mb-0 mt-2"
-            *ngIf="!state.loading && state.tabs[selectedTabIndex].files.length">
+            *ngIf="!state.loading">
             <li *ngFor="let fileInfo of state.tabs[selectedTabIndex].files; trackBy:trackByFn">
                 <span class="btn btn-link btn-padding-0 current">
                     {{ fileInfo.timestamp }}
@@ -47,7 +47,8 @@
                 </span>
             </li>
 
-            <li class="mt-2">
+            <li class="mt-2"
+                *ngIf="state.commonFiles.length">
                 The following records were created before the grouping feature was introduced, and hence, they're displayed for every device.
                 <hr class="mt-0 mb-1">
             </li>


### PR DESCRIPTION
Reproduction

- connect a new device to the computer or delete the device specific user config directory
- open Agent
- navigate to the user configuration page
- select the "new" device tab
- the old user configs should visible 