### PR TITLE
fix: serialisation of "Trigger safety margin" in secondary roles of typing behavior

### DIFF
--- a/packages/uhk-common/src/config-serializer/config-items/user-configuration.ts
+++ b/packages/uhk-common/src/config-serializer/config-items/user-configuration.ts
@@ -295,7 +295,7 @@ export class UserConfiguration implements MouseSpeedConfiguration {
         buffer.writeUInt8(this.secondaryRoleStrategy);
         buffer.writeUInt16(this.secondaryRoleAdvancedStrategyDoubletapTimeout);
         buffer.writeUInt16(this.secondaryRoleAdvancedStrategyTimeout);
-        buffer.writeUInt16(this.secondaryRoleAdvancedStrategySafetyMargin);
+        buffer.writeInt16(this.secondaryRoleAdvancedStrategySafetyMargin);
         buffer.writeBoolean(this.secondaryRoleAdvancedStrategyTriggerByRelease);
         buffer.writeBoolean(this.secondaryRoleAdvancedStrategyDoubletapToPrimary);
         buffer.writeUInt8(this.secondaryRoleAdvancedStrategyTimeoutAction);


### PR DESCRIPTION
closes #2317