### PR TITLE
chore: downgrade electron 33.3.0 => 33.2.1 to fix mac context-menu event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uhk-agent",
-  "version": "4.2.1",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uhk-agent",
-      "version": "4.2.1",
+      "version": "5.0.1",
       "hasInstallScript": true,
       "license": "See in LICENSE",
       "devDependencies": {
@@ -28,7 +28,7 @@
         "decompress": "4.2.1",
         "decompress-targz": "^4.1.1",
         "desm": "1.3.0",
-        "electron": "33.3.0",
+        "electron": "33.2.1",
         "electron-builder": "25.1.8",
         "electron-log": "4.4.8",
         "electron-settings": "4.0.4",
@@ -7480,9 +7480,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "33.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-33.3.0.tgz",
-      "integrity": "sha512-316ZlFUHJmzGrhRj87tVStxyYvknDqVR9eYSsGKAHY7auhVWFLIcPPGxcnbD/H1mez8CpDjXvEjcz76zpWxsXw==",
+      "version": "33.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.2.1.tgz",
+      "integrity": "sha512-SG/nmSsK9Qg1p6wAW+ZfqU+AV8cmXMTIklUL18NnOKfZLlum4ZsDoVdmmmlL39ZmeCaq27dr7CgslRPahfoVJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "decompress": "4.2.1",
     "decompress-targz": "^4.1.1",
     "desm": "1.3.0",
-    "electron": "33.3.0",
+    "electron": "33.2.1",
     "electron-builder": "25.1.8",
     "electron-log": "4.4.8",
     "electron-settings": "4.0.4",


### PR DESCRIPTION
closes #2477. Tested on the 3 major OS

Maybe the https://github.com/electron/electron/pull/44998 PR will fix the issue