### PR TITLE
chore: bump monaco-editor 0.48.0 => 0.50.0

### DIFF
--- a/packages/uhk-web/package-lock.json
+++ b/packages/uhk-web/package-lock.json
@@ -60,7 +60,7 @@
         "karma-coverage": "2.2.1",
         "karma-jasmine": "5.1.0",
         "karma-jasmine-html-reporter": "2.1.0",
-        "monaco-editor": "0.48.0",
+        "monaco-editor": "0.50.0",
         "naive-autocompletion-parser": "1.1.9",
         "ng2-nouislider": "2.0.0",
         "ngrx-store-freeze": "0.2.4",
@@ -10609,9 +10609,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.48.0.tgz",
-      "integrity": "sha512-goSDElNqFfw7iDHMg8WDATkfcyeLTNpBHQpO8incK6p5qZt5G/1j41X0xdGzpIkGojGXM+QiRQyLjnfDVvrpwA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.50.0.tgz",
+      "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/uhk-web/package.json
+++ b/packages/uhk-web/package.json
@@ -68,7 +68,7 @@
     "karma-coverage": "2.2.1",
     "karma-jasmine": "5.1.0",
     "karma-jasmine-html-reporter": "2.1.0",
-    "monaco-editor": "0.48.0",
+    "monaco-editor": "0.50.0",
     "naive-autocompletion-parser": "1.1.9",
     "ng2-nouislider": "2.0.0",
     "ngrx-store-freeze": "0.2.4",


### PR DESCRIPTION
monaco-editor 0.51.0+ does not load. It has amd module loading issue. After the angular upgrade have to check again, because maybe we could switch to esm module