### PR TITLE
chore: log the correct builtFirmwareChecksum of right half firmware

### DIFF
--- a/packages/usb/get-right-firmware-version.ts
+++ b/packages/usb/get-right-firmware-version.ts
@@ -19,7 +19,7 @@ import Uhk, { errorHandler, yargs } from './src/index.js';
         console.log(`smartMacrosVersion: ${version.smartMacrosVersion}`);
         console.log(`firmwareGitRepo: ${version.firmwareGitRepo}`);
         console.log(`firmwareGitTag: ${version.firmwareGitTag}`);
-        console.log(`firmwareChecksum: ${version.firmwareChecksum}`);
+        console.log(`builtFirmwareChecksum: ${version.builtFirmwareChecksum}`);
     } catch (error) {
         await errorHandler(error);
     }


### PR DESCRIPTION
Forget to rename when refactored the naming of the fields in #2510 PR