### PR TITLE
feat: when reordering connections, change the ids of the related device actions accordingly

### DIFF
--- a/packages/uhk-common/src/config-serializer/config-items/host-connection.ts
+++ b/packages/uhk-common/src/config-serializer/config-items/host-connection.ts
@@ -46,6 +46,11 @@ export class HostConnection {
     @assertEnum(HostConnections) type: HostConnections;
 
     address: string;
+    /**
+     * Position in the host connections array.
+     * It is not serialised used to track the reordering.
+     */
+    index: number;
     name: string;
     switchover: boolean;
 
@@ -55,6 +60,7 @@ export class HostConnection {
         if (other) {
             this.type = other.type;
             this.address = other.address;
+            this.index = other.index;
             this.name = other.name;
             this.switchover = other.switchover;
         }

--- a/packages/uhk-common/src/config-serializer/config-items/user-configuration.ts
+++ b/packages/uhk-common/src/config-serializer/config-items/user-configuration.ts
@@ -662,7 +662,9 @@ export class UserConfiguration implements MouseSpeedConfiguration {
         if (this.userConfigMinorVersion >= 1) {
             this.hostConnections = [];
             for(let i = 0; i < HOST_CONNECTION_COUNT_MAX; i++) {
-                this.hostConnections.push(new HostConnection().fromBinary(buffer, serialisationInfo));
+                const hostConnection = new HostConnection().fromBinary(buffer, serialisationInfo);
+                hostConnection.index = i;
+                this.hostConnections.push(hostConnection);
             }
         }
 
@@ -732,7 +734,9 @@ export class UserConfiguration implements MouseSpeedConfiguration {
 
         this.hostConnections = [];
         for (let i = 0; i < HOST_CONNECTION_COUNT_MAX; i++) {
-            this.hostConnections.push(new HostConnection().fromBinary(buffer, serialisationInfo));
+            const hostConnection = new HostConnection().fromBinary(buffer, serialisationInfo);
+            hostConnection.index = i;
+            this.hostConnections.push(hostConnection);
         }
 
         this.moduleConfigurations = buffer.readArray<ModuleConfiguration>(uhkBuffer => {
@@ -927,8 +931,11 @@ export class UserConfiguration implements MouseSpeedConfiguration {
         const serialisationInfo = this.getSerialisationInfo();
 
         if (this.userConfigMinorVersion >= 1) {
-            this.hostConnections = jsonObject.hostConnections.map((hostConnection: any) => {
-                return new HostConnection().fromJsonObject(hostConnection, serialisationInfo);
+            this.hostConnections = jsonObject.hostConnections.map((hostConnection: any, index: number) => {
+                const connection = new HostConnection().fromJsonObject(hostConnection, serialisationInfo)
+                connection.index = index;
+
+                return connection;
             });
         }
 
@@ -995,8 +1002,11 @@ export class UserConfiguration implements MouseSpeedConfiguration {
 
         const serialisationInfo = this.getSerialisationInfo();
 
-        this.hostConnections = jsonObject.hostConnections.map((hostConnection: any) => {
-            return new HostConnection().fromJsonObject(hostConnection, serialisationInfo);
+        this.hostConnections = jsonObject.hostConnections.map((hostConnection: any, index: number) => {
+            const connection = new HostConnection().fromJsonObject(hostConnection, serialisationInfo);
+            connection.index = index;
+
+            return connection;
         });
 
         this.moduleConfigurations = jsonObject.moduleConfigurations.map((moduleConfiguration: any) => {

--- a/packages/uhk-web/src/app/store/reducers/user-configuration.ts
+++ b/packages/uhk-web/src/app/store/reducers/user-configuration.ts
@@ -901,6 +901,7 @@ export function reducer(
         case UserConfig.ActionTypes.ReorderHostConnections: {
             const payload = (action as UserConfig.ReorderHostConnectionsAction).payload;
             const userConfiguration: UserConfiguration = Object.assign(new UserConfiguration(), state.userConfiguration);
+            const processedConnectionActions = new WeakSet<ConnectionsAction>()
             userConfiguration.hostConnections = payload.map((reorderedConnection, index) => {
                 if (reorderedConnection.index === index) {
                     return reorderedConnection;
@@ -913,9 +914,12 @@ export function reducer(
                         layer.modules = layer.modules.map(module => {
                             module = Object.assign(new Module(), module);
                             module.keyActions = module.keyActions.map(keyAction => {
-                                if (keyAction instanceof ConnectionsAction && keyAction.hostConnectionId === reorderedConnection.index) {
+                                if (keyAction instanceof ConnectionsAction
+                                    && keyAction.hostConnectionId === reorderedConnection.index
+                                    && !processedConnectionActions.has(keyAction)) {
                                     const newKeyAction = new ConnectionsAction(keyAction);
                                     newKeyAction.hostConnectionId = index;
+                                    processedConnectionActions.add(newKeyAction);
 
                                     return newKeyAction;
                                 }

--- a/packages/uhk-web/src/app/store/reducers/user-configuration.ts
+++ b/packages/uhk-web/src/app/store/reducers/user-configuration.ts
@@ -1,10 +1,11 @@
-import { HOST_CONNECTION_COUNT_MAX } from 'uhk-common';
 import {
     BacklightingMode,
+    ConnectionsAction,
     Constants,
     emptyHostConnection,
     getDefaultHalvesInfo,
     HalvesInfo,
+    HOST_CONNECTION_COUNT_MAX,
     HostConnection,
     HostConnections,
     initBacklightingColorPalette,
@@ -30,9 +31,9 @@ import {
     SwitchLayerAction,
     UserConfiguration
 } from 'uhk-common';
-import { BleAddingStates } from '../../models';
-import { BleAddingState } from '../../models';
 import {
+    BleAddingStates,
+    BleAddingState,
     BacklightingOption,
     defaultLastEditKey,
     ExchangeKey,
@@ -900,7 +901,42 @@ export function reducer(
         case UserConfig.ActionTypes.ReorderHostConnections: {
             const payload = (action as UserConfig.ReorderHostConnectionsAction).payload;
             const userConfiguration: UserConfiguration = Object.assign(new UserConfiguration(), state.userConfiguration);
-            userConfiguration.hostConnections = payload;
+            userConfiguration.hostConnections = payload.map((reorderedConnection, index) => {
+                if (reorderedConnection.index === index) {
+                    return reorderedConnection;
+                }
+
+                userConfiguration.keymaps = userConfiguration.keymaps.map(keymap => {
+                    keymap = Object.assign(new Keymap(), keymap)
+                    keymap.layers = keymap.layers.map(layer => {
+                        layer = Object.assign(new Layer(), layer);
+                        layer.modules = layer.modules.map(module => {
+                            module = Object.assign(new Module(), module);
+                            module.keyActions = module.keyActions.map(keyAction => {
+                                if (keyAction instanceof ConnectionsAction && keyAction.hostConnectionId === reorderedConnection.index) {
+                                    const newKeyAction = new ConnectionsAction(keyAction);
+                                    newKeyAction.hostConnectionId = index;
+
+                                    return newKeyAction;
+                                }
+
+                                return keyAction;
+                            })
+
+                            return module;
+                        })
+
+                        return layer;
+                    })
+
+                    return keymap;
+                })
+
+                const newConnection = new HostConnection(reorderedConnection);
+                newConnection.index = index;
+
+                return newConnection;
+            })
 
             return {
                 ...state,


### PR DESCRIPTION
closes #2564