### PR TITLE
chore: remove electron-settings from the electron bundle package.json

### DIFF
--- a/packages/uhk-agent/src/package.json
+++ b/packages/uhk-agent/src/package.json
@@ -10,7 +10,6 @@
   },
   "license": "GPL-3.0",
   "dependencies": {
-    "electron-settings": "3.1.4",
     "node-hid": "3.1.2",
     "serialport": "13.0.0"
   }


### PR DESCRIPTION
We bundle `electron-settings` we don't need to install it