### PR TITLE
fix: visibility of the corner of the next/prev layer when screen is very small

### DIFF
--- a/packages/uhk-web/src/app/components/keyboard/slider/keyboard-slider.component.scss
+++ b/packages/uhk-web/src/app/components/keyboard/slider/keyboard-slider.component.scss
@@ -5,11 +5,11 @@
 
 @mixin left-position() {
     left: 0;
-    transform: translateX(-101%);
+    transform: translateX(-110%);
 }
 
 @mixin right-position() {
-    left: 101%;
+    left: 110%;
     transform: translateX(0);
 }
 
@@ -17,7 +17,6 @@ svg-keyboard {
     width: 99%;
     position: absolute;
     left: 0;
-    transform: translateX(-101%);
     user-select: none;
 
     &.center {


### PR DESCRIPTION
It is a quick fix of the https://github.com/UltimateHackingKeyboard/agent/issues/2424#issuecomment-2764764330 .

The "phantom" key is the key from the prev/next layer. This PR is the fastest solution that I could provide now. I don't know how much effort would we like to put in it. 

<img width="338" alt="Screenshot 2025-04-06 at 16 49 36" src="https://github.com/user-attachments/assets/5a93e2a6-bd2d-4e6d-bcb5-893efe9d26a3" />
