### PR TITLE
feat: load earlier / reset user configuration that Agen support

### DIFF
--- a/packages/uhk-agent/src/util/backup-user-configuration.ts
+++ b/packages/uhk-agent/src/util/backup-user-configuration.ts
@@ -4,11 +4,11 @@ import * as path from 'path';
 import {
     BackupUserConfiguration,
     BackupUserConfigurationInfo,
+    convertDateToDisplayText,
     LogService,
     SaveUserConfigurationData,
     shouldUpgradeAgent,
     UserConfiguration,
-    VersionInformation
 } from 'uhk-common';
 
 import { loadUserConfigFromBinaryFile } from './load-user-config-from-binary-file';
@@ -37,7 +37,10 @@ export async function getBackupUserConfigurationContent(logService: LogService, 
                 if (!shouldUpgradeAgent(config.getSemanticVersion(), false)) {
                     logService.config('Backup user configuration', config);
 
+                    const stat = await fs.stat(backupFilePath);
+
                     return {
+                        date: convertDateToDisplayText(stat.mtime),
                         info: BackupUserConfigurationInfo.LastCompatible,
                         userConfiguration: json
                     };

--- a/packages/uhk-common/src/util/helpers.ts
+++ b/packages/uhk-common/src/util/helpers.ts
@@ -2,6 +2,7 @@
 import { Buffer } from '../buffer.js';
 
 import { HardwareConfiguration, UhkBuffer, UserConfiguration } from '../config-serializer/index.js';
+import { shouldUpgradeAgent } from './should-upgrade-agent.js';
 
 export const getHardwareConfigFromDeviceResponse = (json: string): HardwareConfiguration => {
     const data = JSON.parse(json);
@@ -19,16 +20,55 @@ export const getHardwareConfigFromDeviceResponse = (json: string): HardwareConfi
     return hardwareConfig;
 };
 
-export const getUserConfigFromDeviceResponse = (json: string): UserConfiguration => {
-    const data = JSON.parse(json);
-    const userConfig = new UserConfiguration();
-    userConfig.fromBinary(UhkBuffer.fromArray(data));
+export type ParsedUserConfigurationResult = 'invalid' | 'newer' | 'success';
 
-    if (userConfig.userConfigMajorVersion > 0) {
-        return userConfig;
+export interface ParsedUserConfiguration {
+    error?: Error;
+    result: ParsedUserConfigurationResult;
+    userConfiguration?: UserConfiguration;
+    userConfigurationVersion: string;
+}
+
+export const getUserConfigFromDeviceResponse = (json: string): ParsedUserConfiguration => {
+    try {
+        const data = JSON.parse(json);
+        const uhkBuffer = UhkBuffer.fromArray(data)
+        const userConfigMajorVersion = uhkBuffer.readUInt16();
+        const userConfigMinorVersion = uhkBuffer.readUInt16();
+        const userConfigPatchVersion = uhkBuffer.readUInt16();
+        uhkBuffer.offset = 0;
+
+        const userConfigurationVersion = `${userConfigMajorVersion}.${userConfigMinorVersion}.${userConfigPatchVersion}`
+        if (shouldUpgradeAgent(userConfigurationVersion, false)) {
+            return {
+                result: 'newer',
+                userConfigurationVersion,
+            }
+        }
+
+        const userConfig = new UserConfiguration();
+        userConfig.fromBinary(uhkBuffer);
+
+        if (userConfig.userConfigMajorVersion > 0) {
+            return {
+                result: 'success',
+                userConfiguration: userConfig,
+                userConfigurationVersion,
+            };
+        }
+
+        return {
+            result: 'invalid',
+            userConfigurationVersion,
+        };
     }
-
-    throw Error('Invalid user configuration');
+    catch (error) {
+        return {
+            error,
+            userConfigurationVersion: '',
+            result: 'invalid',
+        }
+    }
 };
 
 export const getUserConfigFromJsonObject = (data: any): UserConfiguration  => {

--- a/packages/uhk-common/src/util/user-configuration-history-helpers.ts
+++ b/packages/uhk-common/src/util/user-configuration-history-helpers.ts
@@ -14,3 +14,7 @@ export function convertHistoryFilenameToDisplayText(filename: string): string {
 
     return moment(timestamp, FILENAME_DATE_FORMAT).format(DISPLAY_DATE_FORMAT);
 }
+
+export function convertDateToDisplayText(date: Date): string {
+    return moment(date).format(DISPLAY_DATE_FORMAT);
+}

--- a/packages/uhk-web/src/app/models/index.ts
+++ b/packages/uhk-web/src/app/models/index.ts
@@ -16,6 +16,7 @@ export * from './load-user-configuration-from-file-payload';
 export * from './macro-menu-item';
 export * from './modify-color-of-backlighting-color-palette-payload';
 export * from './navigation-payload';
+export * from './newer-user-configuration';
 export * from './open-popover.model';
 export * from './out-of-space-warning-data';
 export * from './recover-page-state';

--- a/packages/uhk-web/src/app/models/newer-user-configuration.ts
+++ b/packages/uhk-web/src/app/models/newer-user-configuration.ts
@@ -1,0 +1,8 @@
+import { UserConfiguration } from 'uhk-common';
+
+export interface NewerUserConfiguration {
+    date?: string;
+    type: 'reset' | 'backup'
+    newUserConfigurationVersion: string;
+    userConfiguration: UserConfiguration;
+}

--- a/packages/uhk-web/src/app/pages/update-agent.page.ts
+++ b/packages/uhk-web/src/app/pages/update-agent.page.ts
@@ -1,10 +1,19 @@
 import { ChangeDetectionStrategy, Component, ChangeDetectorRef, OnDestroy } from '@angular/core';
+import { Router } from '@angular/router';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 import { Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
 
-import { AppState, isForceUpdate, upgradeAgentTooltip } from '../store';
+import { NewerUserConfiguration } from '../models';
+import {
+    AppState,
+    getNewerUserConfiguration,
+    isForceUpdate,
+    upgradeAgentTooltip,
+} from '../store';
 import { ForceUpdateAction } from '../store/actions/app-update.action';
+import { CheckAreHostConnectionsPairedAction } from '../store/actions/device';
+import { PreviewUserConfigurationAction } from '../store/actions/user-config';
 
 @Component({
     selector: 'update-agent',
@@ -14,7 +23,38 @@ import { ForceUpdateAction } from '../store/actions/app-update.action';
             <uhk-agent-icon class="agent-logo"></uhk-agent-icon>
             <div>
                 <h1>Update Agent</h1>
-                <p>Your UHK contains a <span class="text-dotted" [ngbTooltip]="upgradeAgentTooltip$ | async">newer configuration version</span> than this Agent version can handle, so you must update Agent.</p>
+                <p>
+                    Your UHK contains a <span class="text-dotted" [ngbTooltip]="upgradeAgentTooltip$ | async">newer configuration version</span>
+                    than this Agent version can handle, so you must update Agent.
+                    <br/>
+                    <ng-container *ngIf="newerUserConfiguration?.type === 'backup'">
+                        Or, <a href="#"
+                               mwlConfirmationPopover
+                               popoverTitle="Are you sure?"
+                               placement="bottom"
+                               confirmText="Yes"
+                               cancelText="No"
+                               [class.disabled]="isForceUpdate "
+                               [isDisabled]="isForceUpdate"
+                               (click)="$event.preventDefault()"
+                               (confirm)="onRestoreUserConfiguration()">restore the latest configuration available</a>
+                        compatible with this Agent version (saved at {{ newerUserConfiguration.date }}), and use this
+                        Agent.
+                    </ng-container>
+                    <ng-container *ngIf="newerUserConfiguration?.type === 'reset'">
+                        Or, <a href="#"
+                               mwlConfirmationPopover
+                               popoverTitle="Are you sure?"
+                               placement="bottom"
+                               confirmText="Yes"
+                               cancelText="No"
+                               [class.disabled]="isForceUpdate"
+                               [isDisabled]="isForceUpdate"
+                               (click)="$event.preventDefault()"
+                               (confirm)="onRestoreUserConfiguration()">restore the default configuration</a> and use
+                        this Agent version.
+                    </ng-container>
+                </p>
             </div>
         </div>
         <div style="display: flex; justify-content: center">
@@ -36,13 +76,19 @@ export class UpdateAgentPageComponent implements OnDestroy {
     faSpinner = faSpinner;
     isForceUpdate: boolean;
     upgradeAgentTooltip$: Observable<string>;
+    newerUserConfiguration: NewerUserConfiguration;
 
     private subscriptions = new Subscription();
 
     constructor(private store: Store<AppState>,
-                private cdRef: ChangeDetectorRef) {
+                private cdRef: ChangeDetectorRef,
+                private router: Router,) {
         this.subscriptions.add(store.select(isForceUpdate).subscribe(value => {
             this.isForceUpdate = value;
+            cdRef.markForCheck();
+        }));
+        this.subscriptions.add(store.select(getNewerUserConfiguration).subscribe(newerUserConfiguration => {
+            this.newerUserConfiguration = newerUserConfiguration
             cdRef.markForCheck();
         }));
         this.upgradeAgentTooltip$ = store.select(upgradeAgentTooltip);
@@ -52,6 +98,13 @@ export class UpdateAgentPageComponent implements OnDestroy {
         if (this.subscriptions) {
             this.subscriptions.unsubscribe();
         }
+    }
+
+    onRestoreUserConfiguration(): void {
+        const userConfiguration = this.newerUserConfiguration.userConfiguration;
+        this.store.dispatch(new PreviewUserConfigurationAction(userConfiguration));
+        this.store.dispatch(new CheckAreHostConnectionsPairedAction());
+        this.router.navigate(['/']);
     }
 
     onUpdate(): void {

--- a/packages/uhk-web/src/app/pages/update-agent.page.ts
+++ b/packages/uhk-web/src/app/pages/update-agent.page.ts
@@ -23,7 +23,7 @@ import { PreviewUserConfigurationAction } from '../store/actions/user-config';
             <uhk-agent-icon class="agent-logo"></uhk-agent-icon>
             <div>
                 <h1>Update Agent</h1>
-                <p>
+                <p class="mb-2">
                     Your UHK contains a <span class="text-dotted" [ngbTooltip]="upgradeAgentTooltip$ | async">newer configuration version</span>
                     than this Agent version can handle, so you must update Agent.
                 </p>

--- a/packages/uhk-web/src/app/pages/update-agent.page.ts
+++ b/packages/uhk-web/src/app/pages/update-agent.page.ts
@@ -26,9 +26,10 @@ import { PreviewUserConfigurationAction } from '../store/actions/user-config';
                 <p>
                     Your UHK contains a <span class="text-dotted" [ngbTooltip]="upgradeAgentTooltip$ | async">newer configuration version</span>
                     than this Agent version can handle, so you must update Agent.
-                    <br/>
+                </p>
+                <p>
                     <ng-container *ngIf="newerUserConfiguration?.type === 'backup'">
-                        Or, <a href="#"
+                        Alternatively, <a href="#"
                                mwlConfirmationPopover
                                popoverTitle="Are you sure?"
                                placement="bottom"
@@ -42,7 +43,7 @@ import { PreviewUserConfigurationAction } from '../store/actions/user-config';
                         Agent.
                     </ng-container>
                     <ng-container *ngIf="newerUserConfiguration?.type === 'reset'">
-                        Or, <a href="#"
+                        Alternatively, <a href="#"
                                mwlConfirmationPopover
                                popoverTitle="Are you sure?"
                                placement="bottom"

--- a/packages/uhk-web/src/app/services/default-user-configuration.service.ts
+++ b/packages/uhk-web/src/app/services/default-user-configuration.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { UserConfiguration } from 'uhk-common';
+import { UhkDeviceProduct, UserConfiguration, UHK_80_DEVICE } from 'uhk-common';
 
 @Injectable()
 export class DefaultUserConfigurationService {
@@ -24,5 +24,20 @@ export class DefaultUserConfigurationService {
         }
 
         return this._defaultConfig80;
+    }
+
+    getResetUserConfiguration(uhkDeviceProduct: UhkDeviceProduct): UserConfiguration {
+        let config: UserConfiguration;
+
+        if (uhkDeviceProduct?.id === UHK_80_DEVICE.id) {
+            config = this.getDefault80().clone();
+        }
+        else {
+            config = this.getDefault60().clone();
+        }
+
+        config.keymaps = config.keymaps.filter(keymap => keymap.abbreviation !== 'EMP');
+
+        return config;
     }
 }

--- a/packages/uhk-web/src/app/store/actions/user-config.ts
+++ b/packages/uhk-web/src/app/store/actions/user-config.ts
@@ -5,6 +5,7 @@ import { HostConnection, UserConfiguration, ConfigurationReply } from 'uhk-commo
 import {
     ApplyUserConfigurationFromFilePayload,
     ModifyColorOfBacklightingColorPalettePayload,
+    NewerUserConfiguration,
     UserConfigurationRgbValue,
     UserConfigurationValue,
     LoadUserConfigurationFromFilePayload,
@@ -39,6 +40,7 @@ export enum ActionTypes {
     ApplyUserConfigurationFromFile = '[user-config] Apply user configuration from file',
     PreviewUserConfiguration = '[user-config] Preview user configuration',
     RecoverLEDSpaces = '[user-config] recover LED spaces',
+    UserConfigurationNewer = '[user-config] user configuration is newer that Agent support',
 }
 
 export class AddColorToBacklightingColorPaletteAction implements Action {
@@ -206,6 +208,12 @@ export class RecoverLEDSpacesAction implements Action {
     type = ActionTypes.RecoverLEDSpaces;
 }
 
+export class UserConfigurationNewerAction implements Action {
+    type = ActionTypes.UserConfigurationNewer;
+
+    constructor(public payload?: NewerUserConfiguration) {}
+}
+
 export type Actions
     = AddColorToBacklightingColorPaletteAction
     | AddNewPairedDevicesToHostConnectionsAction
@@ -233,4 +241,5 @@ export type Actions
     | LoadUserConfigurationFromFileAction
     | ApplyUserConfigurationFromFileAction
     | RecoverLEDSpacesAction
+    | UserConfigurationNewerAction
     ;

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -165,6 +165,7 @@ export const showColorPalette = createSelector(userConfigState, fromUserConfig.s
 export const perKeyRgbPresent = createSelector(userConfigState, fromUserConfig.perKeyRgbPresent);
 export const backlightingMode = createSelector(userConfigState, fromUserConfig.backlightingMode);
 export const getBacklightingOptions = createSelector(userConfigState, fromUserConfig.backlightingOptions);
+export const getNewerUserConfiguration = createSelector(userConfigState, fromUserConfig.getNewerUserConfiguration);
 export const hasRecoverableLEDSpace = createSelector(userConfigState, fromUserConfig.hasRecoverableLEDSpace);
 export const backlightingColorPalette = createSelector(userConfigState, fromUserConfig.backlightingColorPalette);
 export const isBacklightingColoring = createSelector(userConfigState, fromUserConfig.isBacklightingColoring);
@@ -474,13 +475,18 @@ export const calculateDeviceUiState = createSelector(
     deviceUiState,
     deviceConfigurationLoaded,
     disableUpdateAgentProtection,
-    (uiState, deviceConfigLoaded, disableUpdateAgentProtection): DeviceUiStates | undefined => {
+    getNewerUserConfiguration,
+    (uiState, deviceConfigLoaded, disableUpdateAgentProtection, newerUserConfiguration): DeviceUiStates | undefined => {
         if (uiState) {
-
-            if(disableUpdateAgentProtection && uiState === DeviceUiStates.UpdateNeeded)
-                return;
-
             return uiState;
+        }
+
+        if (newerUserConfiguration) {
+            if (disableUpdateAgentProtection) {
+                return;
+            }
+
+            return DeviceUiStates.UpdateNeeded;
         }
 
         if (!deviceConfigLoaded) {
@@ -750,9 +756,13 @@ export const getFirmwareUpgradeState = createSelector(runningInElectron, getStat
         };
     });
 export const upgradeAgentTooltip = createSelector(
-    getHardwareModules,
-    (hardwareModules:HardwareModules) => {
-        return `rightModule.userConfigVersion ${hardwareModules.rightModuleInfo.userConfigVersion} minor version is larger than agent.userConfigVersion ${VERSIONS.userConfigVersion}`;
+    getNewerUserConfiguration,
+    (newUserConfiguration) => {
+        if (!newUserConfiguration) {
+            return '';
+        }
+
+        return `rightModule.userConfigVersion ${newUserConfiguration.newUserConfigurationVersion} minor version is larger than agent.userConfigVersion ${VERSIONS.userConfigVersion}`;
     });
 export const upgradeFirmwareTooltip = createSelector(
     getHardwareModules,

--- a/packages/uhk-web/src/app/store/reducers/device.ts
+++ b/packages/uhk-web/src/app/store/reducers/device.ts
@@ -9,14 +9,12 @@ import {
     HalvesInfo,
     HardwareModules,
     isVersionGte,
-    isVersionGtMinor,
     LeftSlotModules,
     RightSlotModules,
     UdevRulesInfo,
     UHK_DEVICE_IDS,
     UHK_DEVICE_IDS_TYPE,
     UhkDeviceProduct,
-    VERSIONS,
 } from 'uhk-common';
 import { DeviceUiStates, EraseBleSettingsButtonState, RecoverPageState } from '../../models';
 import { MissingDeviceState } from '../../models/missing-device-state';
@@ -414,11 +412,6 @@ export const deviceUiState = (state: State): DeviceUiStates | undefined => {
 
     if (!state.connectedDevice) {
         return DeviceUiStates.NotFound;
-    }
-
-    if (state.modules.rightModuleInfo.userConfigVersion
-        && isVersionGtMinor(state.modules.rightModuleInfo.userConfigVersion, VERSIONS.userConfigVersion)) {
-        return DeviceUiStates.UpdateNeeded;
     }
 };
 

--- a/packages/uhk-web/src/app/store/reducers/user-configuration.ts
+++ b/packages/uhk-web/src/app/store/reducers/user-configuration.ts
@@ -39,6 +39,7 @@ import {
     ExchangeKey,
     LastEditedKey,
     LayerOption,
+    NewerUserConfiguration,
     OpenPopoverModel,
     SelectedMacroAction
 } from '../../models';
@@ -75,6 +76,7 @@ export interface State {
     halvesInfo: HalvesInfo;
     newPairedDevices: string[];
     newPairedDevicesAdding: boolean;
+    newerUserConfiguration?: NewerUserConfiguration;
     selectedLayerOption: LayerOption;
     theme: string;
 }
@@ -150,6 +152,7 @@ export function reducer(
         case UserConfig.ActionTypes.LoadUserConfigSuccess: {
             const userConfig = (action as UserConfig.LoadUserConfigSuccessAction).payload;
             const newState = assignUserConfiguration(state, userConfig);
+            newState.newerUserConfiguration = undefined;
             newState.selectedKeymapAbbr = undefined;
             newState.layerOptions = calculateLayerOptions(newState);
 
@@ -195,6 +198,13 @@ export function reducer(
             newState.backlightingColorPalette[payload.index] = payload.color;
 
             return newState;
+        }
+
+        case UserConfig.ActionTypes.UserConfigurationNewer: {
+            return {
+                ...state,
+                newerUserConfiguration: (action as UserConfig.UserConfigurationNewerAction).payload,
+            }
         }
 
         case UserConfig.ActionTypes.ToggleColorFromBacklightingColorPalette: {
@@ -1234,6 +1244,7 @@ export const backlightingOptions = (state: State): Array<BacklightingOption> => 
         }
     ];
 };
+export const getNewerUserConfiguration = (state: State): NewerUserConfiguration => state.newerUserConfiguration;
 export const hasRecoverableLEDSpace = (state: State): boolean => state.userConfiguration.backlightingMode === BacklightingMode.FunctionalBacklighting && state.userConfiguration.perKeyRgbPresent;
 export const backlightingColorPalette = (state: State): Array<RgbColorInterface> => state.backlightingColorPalette;
 export const isBacklightingColoring = (state: State): boolean => state.selectedBacklightingColorIndex > -1;


### PR DESCRIPTION
Offer to load or reset user configuration when keyboard contains newer user configuration that Agent support

Based on #2576 but we don't downgrade the firmware, because it not necessary. closes #2576

Also implements the `If flashed user config version is <= agent's user config version, it should load the config` from #2432

To test the `restore the default configuration`
-  change the `userConfigVersion` version to `9.98.0` in the root package.json

To test the `restore the latest configuration available`:
- change the `userConfigVersion` version to `9.98.0` in the root package.json
- change on of the following if conditions 
   - `if (!shouldUpgradeAgent(config.getSemanticVersion(), false)) {` => `if (true) {` in `packages/uhk-agent/src/util/backup-user-configuration.ts` line 37
   - `if (shouldUpgradeAgent(userConfig.getSemanticVersion(), false)) {` => `if (userConfig.getSemanticVersion() === '9.99.0') {` in `packages/uhk-agent/src/util/backup-user-configuration.ts` line 82

