### PR TITLE
fix: prevent crash when can't parse macro command line from status buffer

### DIFF
--- a/packages/uhk-web/src/app/util/status-buffer-parser.ts
+++ b/packages/uhk-web/src/app/util/status-buffer-parser.ts
@@ -61,6 +61,11 @@ function transformToErrorBlock(macros: Macro[], block: string): any {
     const columnNr = parseInt(line0Result[5], 10);
 
     const line1Result = /^(> \d* \| )(.*)/.exec(lines[1]);
+
+    if (!line1Result || line1Result.length < 3) {
+        return escapeHtml(block);
+    }
+
     const url = `#/macro/${macro.id}?actionIndex=${macroActionIndex}&lineNr=${lineNr}&columnNr=${columnNr}&inlineEdit=true`;
     const newLine2 = `${line1Result[1]}<a href="${url}">${escapeHtml(line1Result[2])}</a>`;
 


### PR DESCRIPTION
The https://github.com/UltimateHackingKeyboard/firmware/releases/tag/v14.2.0 changed the syntax of the macro command error. 

```log
> 4 | ifHold final holduKey 1 <--- before
] 4 | ifHold final holduKey 1 <--- after
```

This PR makes prevent the crashes of the Agent if can't parse the macro line informaition