### PR TITLE
fix: decode keymap abbreviation url parameter

### DIFF
--- a/packages/uhk-web/src/app/components/keymap/edit/keymap-edit.component.ts
+++ b/packages/uhk-web/src/app/components/keymap/edit/keymap-edit.component.ts
@@ -83,7 +83,13 @@ export class KeymapEditComponent implements OnDestroy {
             .pipe(
                 map(params => params.abbr)
             )
-            .subscribe(abbr => store.dispatch(new SelectKeymapAction(abbr)));
+            .subscribe(abbr => {
+                if (abbr) {
+                    abbr = decodeURIComponent(abbr)
+                }
+
+                store.dispatch(new SelectKeymapAction(abbr));
+            });
 
         this.queryParamsSubscription = route.queryParams.subscribe(params => {
             this.selectedLayer = params.layer ? +params.layer : LayerName.base;


### PR DESCRIPTION
closes [#2651](https://github.com/UltimateHackingKeyboard/agent/issues/2651)