### PR TITLE
Make smartMacroDocRootPath writable before copying in doc-dev

### DIFF
--- a/packages/uhk-agent/src/util/copy-smart-macro-doc-to-webserver.ts
+++ b/packages/uhk-agent/src/util/copy-smart-macro-doc-to-webserver.ts
@@ -4,6 +4,7 @@ import { LogService } from 'uhk-common';
 import {getFirmwarePackageJson,TmpFirmware} from 'uhk-usb';
 
 import { getSmartMacroDocRootPath } from './get-smart-macro-doc-root-path';
+import { makeFolderWriteableToUserOnLinux } from '../util';
 
 export async function copySmartMacroDocToWebserver(firmwarePath: TmpFirmware, logger: LogService): Promise<void> {
     logger.misc('[SmartMacroCopy] start');
@@ -26,6 +27,7 @@ export async function copySmartMacroDocToWebserver(firmwarePath: TmpFirmware, lo
 
     const referenceManualFirmwarePath = path.join(firmwarePath.tmpDirectory, 'doc-dev');
     const referenceManualDestination = path.join(destination, 'doc-dev');
+    await makeFolderWriteableToUserOnLinux(destination);
     await cp(referenceManualFirmwarePath, referenceManualDestination, { force: true, recursive: true });
 
     logger.misc('[SmartMacroCopy] done');


### PR DESCRIPTION
For NixOS users, the destination directory here is not writable, but
it should be. This was originally reported in NixOS/nixpkgs#423634

Fixes #2679