### PR TITLE
fix: enhance the version information tooltip of Agent upgrade page

### DIFF
--- a/packages/uhk-web/src/app/pages/update-agent.page.ts
+++ b/packages/uhk-web/src/app/pages/update-agent.page.ts
@@ -24,8 +24,11 @@ import { PreviewUserConfigurationAction } from '../store/actions/user-config';
             <uhk-agent-icon class="agent-logo"></uhk-agent-icon>
             <div>
                 <h1>Update Agent</h1>
+                <ng-template #upgradeAgentTooltip>
+                    <div [innerHTML]="upgradeAgentTooltip$ | async | safeHtml"></div>
+                </ng-template>
                 <p class="mb-2">
-                    Your UHK contains a <span class="text-dotted" [ngbTooltip]="upgradeAgentTooltip$ | async">newer configuration version</span>
+                    Your UHK contains a <span class="text-dotted" [ngbTooltip]="upgradeAgentTooltip" tooltipClass="tooltip-firmware-checksum">newer configuration version</span>
                     than this Agent version can handle, so you must update Agent.
                 </p>
                 <p>

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -764,12 +764,13 @@ export const getFirmwareUpgradeState = createSelector(runningInElectron, getStat
     });
 export const upgradeAgentTooltip = createSelector(
     getNewerUserConfiguration,
-    (newUserConfiguration) => {
+    getHardwareModules,
+    (newUserConfiguration, hardwareModules) => {
         if (!newUserConfiguration) {
             return '';
         }
 
-        return `rightModule.userConfigVersion ${newUserConfiguration.newUserConfigurationVersion} minor version is larger than agent.userConfigVersion ${VERSIONS.userConfigVersion}`;
+        return `rightHalf.firmware.userConfigVersion ${hardwareModules.rightModuleInfo.userConfigVersion} minor version is larger than agent.userConfigVersion ${VERSIONS.userConfigVersion}. <br /> <br /> rightHalf.flashedUserConfigVersion: ${newUserConfiguration.newUserConfigurationVersion}`;
     });
 export const upgradeFirmwareTooltip = createSelector(
     getHardwareModules,


### PR DESCRIPTION
closes: #2432

I think only the tooltip content enhancement missing from the linked issue.  Other things had been implemented earlier. If anything else missing please let me know.