### PR TITLE
feat: show warning when creating layer switch actions on all keymaps targeting a non-existing layer

### DIFF
--- a/packages/uhk-web/src/app/components/popover/popover.component.html
+++ b/packages/uhk-web/src/app/components/popover/popover.component.html
@@ -29,10 +29,13 @@
                       (keyActionChange)="keystrokeActionChange($event)"
         ></keypress-tab>
         <layer-tab #tab *ngSwitchCase="tabName.Layer" class="popover-content"
+                   [allowRemapOnAllKeymapWarning]="true"
                    [defaultKeyAction]="defaultKeyAction"
                    [currentLayer]="currentLayer"
                    [allowLayerDoubleTap]="allowLayerDoubleTap"
                    [layerOptions]="layerOptions$ | async"
+                   [remapInfo]="internalRemapInfo"
+                   [userConfiguration]="userConfiguration$ | async"
                    (validAction)="setKeyActionValidState($event)"
         ></layer-tab>
         <mouse-tab #tab *ngSwitchCase="tabName.Mouse" class="popover-content"
@@ -71,7 +74,8 @@
                     <input type="checkbox" class="form-check-input"
                         id="remapOnAllKeymap"
                         name="remapOnAllKeymap"
-                        [(ngModel)]="internalRemapInfo.remapOnAllKeymap">
+                        [(ngModel)]="internalRemapInfo.remapOnAllKeymap"
+                        (ngModelChange)="remapInfoChange()">
                     <label class="form-check-label" for="remapOnAllKeymap">Remap on all keymaps</label>
                 </div>
                 <div class="form-check">

--- a/packages/uhk-web/src/app/components/popover/popover.component.ts
+++ b/packages/uhk-web/src/app/components/popover/popover.component.ts
@@ -28,7 +28,8 @@ import {
     SecondaryRoleAction,
     UhkThemeColors,
     SwitchKeymapAction,
-    SwitchLayerAction
+    SwitchLayerAction,
+    UserConfiguration,
 } from 'uhk-common';
 
 import { SelectedKeyModel } from '../../models';
@@ -40,6 +41,7 @@ import {
     getKeymaps,
     getLayerOptions,
     getUhkThemeColors,
+    getUserConfiguration,
     macroPlaybackSupported
 } from '../../store';
 import { KeyActionRemap } from '../../models/key-action-remap';
@@ -137,6 +139,7 @@ export class PopoverComponent implements OnChanges {
     ];
     macroPlaybackSupported$: Observable<boolean>;
     layerOptions$: Observable<LayerOption[]>;
+    userConfiguration$: Observable<UserConfiguration>;
 
     constructor(private store: Store<AppState>,
                 private cdRef: ChangeDetectorRef) {
@@ -145,6 +148,7 @@ export class PopoverComponent implements OnChanges {
         this.keymapOptions$ = store.select(getKeymapOptions);
         this.macroPlaybackSupported$ = store.select(macroPlaybackSupported);
         this.layerOptions$ = store.select(getLayerOptions);
+        this.userConfiguration$ = store.select(getUserConfiguration);
     }
 
     ngOnChanges(change: SimpleChanges) {

--- a/packages/uhk-web/src/app/components/popover/tab/layer/layer-tab.component.html
+++ b/packages/uhk-web/src/app/components/popover/tab/layer/layer-tab.component.html
@@ -38,6 +38,10 @@
                 <label class="form-check-label" for="lockLayerDoubleTap">Lock layer when double tapping this key.</label>
             </div>
         </div>
+
+        <div *ngIf="showWarning" class="alert alert-warning remap-warning" role="alert">
+            You're targeting the <strong>{{ layerDisplayText }}</strong> layer on all keymaps, some of which don't have this layer. This mapping will only be added to keymaps that have the <strong>{{ layerDisplayText }}</strong> layer.
+        </div>
     </div>
 </ng-template>
 <ng-template [ngIf]="isNotBase">

--- a/packages/uhk-web/src/app/components/popover/tab/layer/layer-tab.component.scss
+++ b/packages/uhk-web/src/app/components/popover/tab/layer/layer-tab.component.scss
@@ -21,4 +21,11 @@
         display: inline-block;
         width: 6em;
     }
+
+    .remap-warning {
+        margin-top: 10px;
+        margin-bottom: 0;
+        padding-top: 5px;
+        padding-bottom: 5px;
+    }
 }


### PR DESCRIPTION
closes: #2309