### PR TITLE
ci: use macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
`macos-13` runner is deprecated. Let's try to use the latest version. We downgraded earlier because of https://github.com/electron/notarize/issues/219