### PR TITLE
feat: show invalid codesign signature alert

### DIFF
--- a/packages/uhk-agent/src/electron-main.ts
+++ b/packages/uhk-agent/src/electron-main.ts
@@ -118,7 +118,7 @@ async function createWindow() {
 
     setMenu(win, options.devtools);
     deviceService = new DeviceService(logger, win, uhkHidDeviceService, uhkOperations, options, packagesDir);
-    appUpdateService = new AppUpdateService(logger, win, app);
+    appUpdateService = new AppUpdateService(logger, win, options);
     appService = new AppService(logger, win, deviceService, options, packagesDir);
     sudoService = new SudoService(logger, options, deviceService, packagesDir);
     // and load the index.html of the app.

--- a/packages/uhk-agent/src/util/command-line.ts
+++ b/packages/uhk-agent/src/util/command-line.ts
@@ -21,6 +21,7 @@ const optionDefinitions: commandLineArgs.OptionDefinition[] = [
     { name: 'reenumerate-and-exit', type: String },
     { name: 'report-id', type: Number },
     { name: 'serial-number', type: String },
+    { name: 'simulate-invalid-codesign-signature', type: Boolean },
     { name: 'spe', type: Boolean }, // simulate privilege escalation error
     { name: 'usb-interface', type: Number },
     { name: 'usb-non-blocking', type: Boolean },
@@ -119,6 +120,11 @@ const sections: commandLineUsage.Section[] = [
                 name: 'serial-number',
                 description: 'Use the specified USB device that serial-number is matching.',
                 type: String
+            },
+            {
+                name: 'simulate-invalid-codesign-signature',
+                description: 'Agent shows the invalid code sign signature error 10 seconds after start',
+                type: Boolean
             },
             {
                 name: 'spe',

--- a/packages/uhk-common/src/models/command-line-args.ts
+++ b/packages/uhk-common/src/models/command-line-args.ts
@@ -83,6 +83,11 @@ export interface CommandLineArgs extends DeviceIdentifier {
      * Report Id that used for USB communication
      */
     'report-id'?: number;
+
+    /**
+     * Agent shows the invalid code sign signature error 10 seconds after start
+     */
+    'simulate-invalid-codesign-signature'?: boolean;
     /**
      * simulate privilege escalation error
      */

--- a/packages/uhk-common/src/util/constants.ts
+++ b/packages/uhk-common/src/util/constants.ts
@@ -7,3 +7,4 @@ export namespace Constants {
 }
 
 export const UHK_EEPROM_SIZE = 32768;
+export const ERR_UPDATER_INVALID_SIGNATURE = 'ERR_UPDATER_INVALID_SIGNATURE'

--- a/packages/uhk-web/src/app/app.component.html
+++ b/packages/uhk-web/src/app/app.component.html
@@ -65,3 +65,18 @@
 <out-of-space-warning *ngIf="outOfSpaceWarning.show"
                       [@showOutOfSpaceWarning]
                       [state]="outOfSpaceWarning"></out-of-space-warning>
+<ng-template #manuallyUpdateNotification>
+    <p class="notifier__notification-message">
+    Agent's digital signature has changed. Please  <a href="https://uhk.io/agent" class="alert-link" externalUrl>update it manually</a> this time. Agent will auto-update afterward.
+    </p>
+    <button
+        class="notifier__notification-button"
+        type="button"
+        title="dismiss"
+        (click)="dismissUpdateErrorNotification()"
+    >
+        <svg class="notifier__notification-button-icon" viewBox="0 0 24 24" width="20" height="20">
+            <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+        </svg>
+    </button>
+</ng-template>

--- a/packages/uhk-web/src/app/store/actions/app-update.action.ts
+++ b/packages/uhk-web/src/app/store/actions/app-update.action.ts
@@ -4,6 +4,7 @@ import { UpdateInfo } from '../../models/update-info';
 
 export enum ActionTypes {
     ForceUpdate = '[app-update] force update',
+    InvalidCodesignSignature = '[app-update] invalid codesign signature',
     UpdateAvailable = '[app-update] update available',
     UpdateApp = '[app-update] update app',
     DoNotUpdateApp = '[app-update] do not update app',
@@ -14,6 +15,10 @@ export enum ActionTypes {
 
 export class ForceUpdateAction implements Action {
     type = ActionTypes.ForceUpdate;
+}
+
+export class InvalidCodesignSignatureAction implements Action {
+    type = ActionTypes.InvalidCodesignSignature;
 }
 
 export class UpdateAvailableAction implements Action {
@@ -48,6 +53,7 @@ export class UpdateErrorAction implements Action {
 
 export type Actions
     = UpdateAvailableAction
+    | InvalidCodesignSignatureAction
     | UpdateAppAction
     | DoNotUpdateAppAction
     | UpdateDownloadedAction

--- a/packages/uhk-web/src/app/store/effects/app-update.ts
+++ b/packages/uhk-web/src/app/store/effects/app-update.ts
@@ -4,11 +4,12 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { EMPTY } from 'rxjs';
 import { first, map, tap, withLatestFrom } from 'rxjs/operators';
 
-import { LogService, NotificationType } from 'uhk-common';
+import { ERR_UPDATER_INVALID_SIGNATURE, LogService, NotificationType } from 'uhk-common';
 
 import {
     ActionTypes,
     ForceUpdateAction,
+    InvalidCodesignSignatureAction,
     UpdateAppAction,
     UpdateAvailableAction,
     UpdateErrorAction
@@ -74,6 +75,10 @@ export class AppUpdateEffect {
             ofType<UpdateErrorAction>(ActionTypes.UpdateError),
             map(action => action.payload),
             map((message: string) => {
+                if (message === ERR_UPDATER_INVALID_SIGNATURE) {
+                    return new InvalidCodesignSignatureAction();
+                }
+
                 return new ShowNotificationAction({
                     type: NotificationType.Error,
                     message

--- a/packages/uhk-web/src/styles/_global.scss
+++ b/packages/uhk-web/src/styles/_global.scss
@@ -321,3 +321,7 @@ mwl-confirmation-popover-window {
         cursor: not-allowed;
     }
 }
+
+.alert-link {
+    text-decoration: underline;
+}


### PR DESCRIPTION
close #2773

I introduced the `simulate-invalid-codesign-signature` command line argument to test the functionality. We could remove it before the merge or we could kept it for future testing.
If the argument provided the Agent show the alert 10 seconds after the start

The whole start command `npm run electron -- -- -- --simulate-invalid-codesign-signature`