### PR TITLE
chore: use @vscode/sudo-prompt instead of unmaintained sudo-prompt

### DIFF
--- a/packages/uhk-agent/package-lock.json
+++ b/packages/uhk-agent/package-lock.json
@@ -10,6 +10,7 @@
       "license": "See in LICENSE",
       "dependencies": {
         "@fastify/static": "9.0.0",
+        "@vscode/sudo-prompt": "9.3.2",
         "command-line-args": "6.0.1",
         "command-line-usage": "7.0.3",
         "decompress": "4.2.1",
@@ -22,7 +23,6 @@
         "node-hid": "3.2.0",
         "p-limit": "7.1.1",
         "serialport": "13.0.0",
-        "sudo-prompt": "9.2.1",
         "tmp": "0.2.5",
         "tslib": "2.8.1"
       }
@@ -430,6 +430,12 @@
       "funding": {
         "url": "https://opencollective.com/serialport/donate"
       }
+    },
+    "node_modules/@vscode/sudo-prompt": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
+      "integrity": "sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==",
+      "license": "MIT"
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -2236,13 +2242,6 @@
       "dependencies": {
         "is-natural-number": "^4.0.1"
       }
-    },
-    "node_modules/sudo-prompt": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-      "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/packages/uhk-agent/package.json
+++ b/packages/uhk-agent/package.json
@@ -12,6 +12,7 @@
   "license": "See in LICENSE",
   "dependencies": {
     "@fastify/static": "9.0.0",
+    "@vscode/sudo-prompt": "9.3.2",
     "command-line-args": "6.0.1",
     "command-line-usage": "7.0.3",
     "electron-is-dev": "3.0.1",
@@ -24,7 +25,6 @@
     "node-hid": "3.2.0",
     "p-limit": "7.1.1",
     "serialport": "13.0.0",
-    "sudo-prompt": "9.2.1",
     "tmp": "0.2.5",
     "tslib": "2.8.1",
     "uhk-common": "^1.0.0",

--- a/packages/uhk-agent/src/services/sudo.service.ts
+++ b/packages/uhk-agent/src/services/sudo.service.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import * as path from 'path';
-import * as sudo from 'sudo-prompt';
+import * as sudo from '@vscode/sudo-prompt';
 import { dirSync } from 'tmp';
 import { emptyDir, copy } from 'fs-extra';
 


### PR DESCRIPTION
The old sudo-prompt uses node util functions that removed from node 24. Electron 40 uses node 24