### PR TITLE
Enable logging buffer UI for uhk60.

### DIFF
--- a/packages/uhk-agent/src/services/device.service.ts
+++ b/packages/uhk-agent/src/services/device.service.ts
@@ -1420,12 +1420,13 @@ export class DeviceService {
 
     private async readZephyrLog(): Promise<void> {
         try {
+            const uhkDeviceProduct = await getCurrentUhkDeviceProduct(this.options);
             const log = await this.operations.getVariable(UsbVariables.ShellBuffer)
             this.logService.misc(`[DeviceService] Right half zephyr log: ${log}`);
             const logEntry: ZephyrLogEntry = {
                 log: log as string,
                 level: 'info',
-                device: UHK_80_DEVICE.logName,
+                device: uhkDeviceProduct.logName,
             }
             this.win.webContents.send(IpcEvents.device.zephyrLog, logEntry)
         }

--- a/packages/uhk-web/src/app/components/device/advanced-settings/advanced-settings.page.component.html
+++ b/packages/uhk-web/src/app/components/device/advanced-settings/advanced-settings.page.component.html
@@ -63,7 +63,7 @@
                             [disabled]="state.isLeftHalfPairing"
                             (click)="onToggleZephyrLogging()"
                     >
-                        Zephyr logging
+                        Logging
                     </button>
                 </div>
             </div>

--- a/packages/uhk-web/src/app/components/device/advanced-settings/advanced-settings.page.component.ts
+++ b/packages/uhk-web/src/app/components/device/advanced-settings/advanced-settings.page.component.ts
@@ -87,7 +87,9 @@ export class AdvancedSettingsPageComponent implements OnInit, OnDestroy {
         this.connectedDeviceSubscription = this.store.select(getConnectedDevice)
             .subscribe(connectedDevice => {
                 this.isHalvesPairingAllowed = connectedDevice?.id === UHK_80_DEVICE.id;
-                this.isZephyrLoggingAllowed = connectedDevice?.id === UHK_80_DEVICE.id;
+                this.isZephyrLoggingAllowed = connectedDevice?.id === UHK_80_DEVICE.id
+                    || connectedDevice?.id === UHK_60_DEVICE.id
+                    || connectedDevice?.id === UHK_60_V2_DEVICE.id;
                 this.showI2CRecoverButton = connectedDevice?.id === UHK_60_DEVICE.id ||  connectedDevice?.id === UHK_60_V2_DEVICE.id;
                 this.cdRef.detectChanges();
             });

--- a/packages/uhk-web/src/app/components/device/advanced-settings/advanced-settings.page.component.ts
+++ b/packages/uhk-web/src/app/components/device/advanced-settings/advanced-settings.page.component.ts
@@ -87,9 +87,7 @@ export class AdvancedSettingsPageComponent implements OnInit, OnDestroy {
         this.connectedDeviceSubscription = this.store.select(getConnectedDevice)
             .subscribe(connectedDevice => {
                 this.isHalvesPairingAllowed = connectedDevice?.id === UHK_80_DEVICE.id;
-                this.isZephyrLoggingAllowed = connectedDevice?.id === UHK_80_DEVICE.id
-                    || connectedDevice?.id === UHK_60_DEVICE.id
-                    || connectedDevice?.id === UHK_60_V2_DEVICE.id;
+                this.isZephyrLoggingAllowed = !!connectedDevice;
                 this.showI2CRecoverButton = connectedDevice?.id === UHK_60_DEVICE.id ||  connectedDevice?.id === UHK_60_V2_DEVICE.id;
                 this.cdRef.detectChanges();
             });


### PR DESCRIPTION
Uhk60 now allows logging into the same usb buffer as the one used by (formerly) zephyr logging. 