### PR TITLE
fix: don't use ALT key for export keyboard layout in svg

### DIFF
--- a/packages/uhk-web/src/app/app.component.ts
+++ b/packages/uhk-web/src/app/app.component.ts
@@ -251,9 +251,8 @@ export class MainAppComponent implements OnDestroy {
     onKeyDown(event: KeyboardEvent) {
         // It should be before the CTRL + S to prevent the conflict with the SaveToKeyboard shortcut
         if (event.ctrlKey &&
-            event.altKey &&
             event.shiftKey &&
-            event.code === 'KeyS' &&
+            event.key === 'S' &&
             !event.defaultPrevented &&
             !this.keypressCapturing) {
             this.keyboardSvgExportService.downloadSvgKeyboard();


### PR DESCRIPTION
The event.key contains the real user key press, but the ALT key modifies it based on the keyboard layout and local setting.

closes: #2866