### PR TITLE
fix: resolve uhk-common Buffer import for file: dependencies

### DIFF
--- a/packages/uhk-common/src/buffer.ts
+++ b/packages/uhk-common/src/buffer.ts
@@ -1,1 +1,3 @@
-export { Buffer } from '../node_modules/buffer/index.js';
+import { Buffer as NodeBuffer } from 'buffer';
+
+export const Buffer = NodeBuffer;

--- a/packages/uhk-common/src/config-serializer/uhk-buffer.ts
+++ b/packages/uhk-common/src/config-serializer/uhk-buffer.ts
@@ -28,7 +28,7 @@ export class UhkBuffer {
 
     private static maxCompactLength = 0xFFFF;
     private static longCompactLengthPrefix = 0xFF;
-    private static stringEncoding = 'utf8';
+    private static readonly stringEncoding = 'utf8' as const;
     private static isFirstElementToDump = false;
 
     offset: number;

--- a/packages/uhk-web/src/app/store/effects/user-config.ts
+++ b/packages/uhk-web/src/app/store/effects/user-config.ts
@@ -306,7 +306,7 @@ export class UserConfigEffects {
                 const newUserConfiguration= updateUserConfigurationWithLastSaveInfo(userConfiguration, hardwareModules.rightModuleInfo);
                 const uhkBuffer = new UhkBuffer();
                 newUserConfiguration.toBinary(uhkBuffer);
-                const blob = new Blob([uhkBuffer.getBufferContent()]);
+                const blob = new Blob([new Uint8Array(uhkBuffer.getBufferContent())]);
                 saveAs(blob, 'UserConfiguration.bin');
             })
         ),


### PR DESCRIPTION
## Summary

Fixes a renderer build failure when `uhk-web` installs `uhk-common` via `file:../uhk-common`.

`uhk-common/src/buffer.ts` re-exported `Buffer` through a relative path into its own `node_modules`:

```ts
export { Buffer } from '../node_modules/buffer/index.js';
```

That works when building inside `uhk-common`, but `npm` copies `file:` dependencies **without** nested `node_modules`. Webpack then fails:

```
Can't resolve '../node_modules/buffer/index.js' in '.../uhk-web/node_modules/uhk-common/dist'
```

This can surface after any `uhk-web` `npm install` that refreshes the local `uhk-common` copy (e.g. adding a dev dependency).

## Changes

- Import `Buffer` from the `buffer` package directly in `uhk-common`
- Mark `UhkBuffer.stringEncoding` as `'utf8' as const` for `BufferEncoding` typing
- Wrap saved user-config bytes in `Uint8Array` for `Blob` construction in the web renderer

## Test plan

- [ ] `cd packages/uhk-common && npm run build`
- [ ] `rm -rf packages/uhk-web/node_modules/uhk-common && cd packages/uhk-web && npm install`
- [ ] `rm -rf packages/uhk-web/.angular/cache && npm run build:renderer` succeeds
- [ ] Save user configuration as `.bin` from the web UI still works


Made with [Cursor](https://cursor.com)