### PR TITLE
feat: add always enable advanced settings Agent setting

### DIFF
--- a/packages/uhk-common/src/models/application-settings.ts
+++ b/packages/uhk-common/src/models/application-settings.ts
@@ -30,4 +30,8 @@ export interface ApplicationSettings {
      * Smart Macro panel width in percent;
      */
     smartMacroPanelWidth?: number;
+    /**
+     * If true, the Advanced settings menu is shown on Agent startup.
+     */
+    alwaysEnableAdvancedMode?: boolean;
 }

--- a/packages/uhk-web/src/app/components/agent/settings/settings.component.html
+++ b/packages/uhk-web/src/app/components/agent/settings/settings.component.html
@@ -33,6 +33,17 @@
     </div>
 </div>
 
+<div class="col-12 mt-1" *ngIf="alwaysEnableAdvancedModeSettingVisible$ | async">
+    <div class="checkbox d-inline-block mb-0 mt-0">
+        <label>
+            <input type="checkbox"
+                   [checked]="alwaysEnableAdvancedMode$ | async"
+                   (change)="toggleAlwaysEnableAdvancedMode($event.target.checked)"
+            > Always enable advanced settings
+        </label>
+    </div>
+</div>
+
 
 <div class="col-12 col-md-6 mb-0 mt-0">
     <div class="d-flex align-items-center mt-2">

--- a/packages/uhk-web/src/app/components/agent/settings/settings.component.ts
+++ b/packages/uhk-web/src/app/components/agent/settings/settings.component.ts
@@ -8,6 +8,8 @@ import { AppTheme, AppThemeSelect } from 'uhk-common';
 import {
     AppState,
     appUpdateSettingsState,
+    getAlwaysEnableAdvancedMode,
+    getAlwaysEnableAdvancedModeSettingVisible,
     getAnimationEnabled,
     getAppTheme,
     getOperatingSystem,
@@ -20,6 +22,7 @@ import {
     ToggleCheckForUpdateOnStartupAction
 } from '../../../store/actions/auto-update-settings';
 import { OpenConfigFolderAction, SetAppThemeAction, ToggleAnimationEnabledAction, ToggleKeyboardHalvesAlwaysJoinedAction } from '../../../store/actions/app';
+import { ToggleAlwaysEnableAdvancedModeAction } from '../../../store/actions/advance-settings.action';
 import { OperatingSystem } from '../../../models/operating-system';
 
 @Component({
@@ -39,6 +42,8 @@ export class SettingsComponent {
     isLinux$: Observable<boolean>;
     faCog = faCog;
     keyboardHalvesAlwaysJoined$: Observable<boolean>;
+    alwaysEnableAdvancedMode$: Observable<boolean>;
+    alwaysEnableAdvancedModeSettingVisible$: Observable<boolean>;
 
     constructor(private store: Store<AppState>) {
         this.updateSettingsState$ = store.select(appUpdateSettingsState);
@@ -47,6 +52,8 @@ export class SettingsComponent {
         this.themes$ = store.select(getSupportedThemes);
         this.isLinux$ = store.select(getOperatingSystem).pipe(map(os => os === OperatingSystem.Linux));
         this.keyboardHalvesAlwaysJoined$ = store.select(keyboardHalvesAlwaysJoined);
+        this.alwaysEnableAdvancedMode$ = store.select(getAlwaysEnableAdvancedMode);
+        this.alwaysEnableAdvancedModeSettingVisible$ = store.select(getAlwaysEnableAdvancedModeSettingVisible);
     }
 
     openConfigFolder(): void {
@@ -71,6 +78,10 @@ export class SettingsComponent {
 
     toggleKeyboardHalvesAlwaysJoined(enabled: boolean): void {
         this.store.dispatch(new ToggleKeyboardHalvesAlwaysJoinedAction(enabled));
+    }
+
+    toggleAlwaysEnableAdvancedMode(enabled: boolean): void {
+        this.store.dispatch(new ToggleAlwaysEnableAdvancedModeAction(enabled));
     }
 
 }

--- a/packages/uhk-web/src/app/components/agent/settings/settings.component.ts
+++ b/packages/uhk-web/src/app/components/agent/settings/settings.component.ts
@@ -9,9 +9,9 @@ import {
     AppState,
     appUpdateSettingsState,
     getAlwaysEnableAdvancedMode,
-    getAlwaysEnableAdvancedModeSettingVisible,
     getAnimationEnabled,
     getAppTheme,
+    getIsAdvancedSettingsMenuVisible,
     getOperatingSystem,
     getSupportedThemes,
     keyboardHalvesAlwaysJoined
@@ -53,7 +53,7 @@ export class SettingsComponent {
         this.isLinux$ = store.select(getOperatingSystem).pipe(map(os => os === OperatingSystem.Linux));
         this.keyboardHalvesAlwaysJoined$ = store.select(keyboardHalvesAlwaysJoined);
         this.alwaysEnableAdvancedMode$ = store.select(getAlwaysEnableAdvancedMode);
-        this.alwaysEnableAdvancedModeSettingVisible$ = store.select(getAlwaysEnableAdvancedModeSettingVisible);
+        this.alwaysEnableAdvancedModeSettingVisible$ = store.select(getIsAdvancedSettingsMenuVisible);
     }
 
     openConfigFolder(): void {

--- a/packages/uhk-web/src/app/store/actions/advance-settings.action.ts
+++ b/packages/uhk-web/src/app/store/actions/advance-settings.action.ts
@@ -19,6 +19,7 @@ export enum ActionTypes {
     toggleRightHalfZephyrLogging = '[advanceSettings] toggle right half zephyr logging',
     toggleZephyrLogging = '[advanceSettings] toggle zephyr logging',
     showAdvancedSettingsMenu = '[advanceSettings] show menu',
+    toggleAlwaysEnableAdvancedMode = '[advanceSettings] toggle always enable advanced mode',
     zephyrLog = '[advanceSettings] zephyr log',
 }
 
@@ -103,6 +104,12 @@ export class ShowAdvancedSettingsMenuAction implements Action {
     type = ActionTypes.showAdvancedSettingsMenu;
 }
 
+export class ToggleAlwaysEnableAdvancedModeAction implements Action {
+    type = ActionTypes.toggleAlwaysEnableAdvancedMode;
+
+    constructor(public payload: boolean) {}
+}
+
 export class ZephyrLogAction implements Action {
     type = ActionTypes.zephyrLog;
 
@@ -124,6 +131,7 @@ export type Actions =
     | ToggleRightHalfZephyrLoggingAction
     | ToggleZephyrLoggingAction
     | ShowAdvancedSettingsMenuAction
+    | ToggleAlwaysEnableAdvancedModeAction
     | StartLeftHalfPairingAction
     | LeftHalfPairingSuccessAction
     | LeftHalfPairingFailedAction

--- a/packages/uhk-web/src/app/store/effects/app.ts
+++ b/packages/uhk-web/src/app/store/effects/app.ts
@@ -29,6 +29,7 @@ import {
     UndoLastAction
 } from '../actions/app';
 import { ActionTypes as UpdateActionTypes } from '../actions/auto-update-settings';
+import { ActionTypes as AdvanceSettingsActionTypes } from '../actions/advance-settings.action';
 import { AppRendererService } from '../../services/app-renderer.service';
 import { AppUpdateRendererService } from '../../services/app-update-renderer.service';
 import { ActionTypes as DeviceActionTypes, StartConnectionPollerAction } from '../actions/device';
@@ -145,6 +146,7 @@ export class ApplicationEffects {
                 ActionTypes.SetAppTheme,
                 ActionTypes.ToggleAnimationEnabled,
                 ActionTypes.ToggleKeyboardHalvesAlwaysJoined,
+                AdvanceSettingsActionTypes.toggleAlwaysEnableAdvancedMode,
                 UpdateActionTypes.ToggleCheckForUpdateOnStartup,
                 DeviceActionTypes.SaveConfiguration,
                 SmartMacroDocActionTypes.PanelSizeChanged,

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -116,6 +116,8 @@ export const metaReducers: MetaReducer<AppState>[] = environment.production
 
 export const advanceSettingsState = (state: AppState) => state.advanceSettings;
 export const getIsAdvancedSettingsMenuVisible = createSelector(advanceSettingsState, fromAdvancedSettings.isAdvancedSettingsMenuVisible);
+export const getAlwaysEnableAdvancedMode = createSelector(advanceSettingsState, fromAdvancedSettings.isAlwaysEnableAdvancedMode);
+export const getAlwaysEnableAdvancedModeSettingVisible = createSelector(advanceSettingsState, fromAdvancedSettings.isAlwaysEnableAdvancedModeSettingVisible);
 export const isLeftHalfPairing = createSelector(advanceSettingsState, fromAdvancedSettings.isLeftHalfPairing);
 export const getIsI2cDebuggingEnabled = createSelector(advanceSettingsState, fromAdvancedSettings.isI2cDebuggingEnabled);
 export const isI2cDebuggingRingBellEnabled = createSelector(advanceSettingsState, fromAdvancedSettings.isI2cDebuggingRingBellEnabled);
@@ -829,11 +831,13 @@ export const getApplicationSettings = createSelector(
     getSmartMacroPanelWidth,
     backlightingColorPalette,
     keyboardHalvesAlwaysJoined,
+    getAlwaysEnableAdvancedMode,
     (updateSettingsState,
         app,
         smartMacroPanelWidth,
         backlightingColorPalette,
         keyboardHalvesAlwaysJoined,
+        alwaysEnableAdvancedMode,
     ): ApplicationSettings => {
         return {
             errorPanelHeight: app.errorPanelHeight,
@@ -843,6 +847,7 @@ export const getApplicationSettings = createSelector(
             appTheme: app.appTheme,
             backlightingColorPalette,
             keyboardHalvesAlwaysJoined,
+            alwaysEnableAdvancedMode,
             smartMacroPanelWidth
         };
     });

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -117,7 +117,6 @@ export const metaReducers: MetaReducer<AppState>[] = environment.production
 export const advanceSettingsState = (state: AppState) => state.advanceSettings;
 export const getIsAdvancedSettingsMenuVisible = createSelector(advanceSettingsState, fromAdvancedSettings.isAdvancedSettingsMenuVisible);
 export const getAlwaysEnableAdvancedMode = createSelector(advanceSettingsState, fromAdvancedSettings.isAlwaysEnableAdvancedMode);
-export const getAlwaysEnableAdvancedModeSettingVisible = createSelector(advanceSettingsState, fromAdvancedSettings.isAlwaysEnableAdvancedModeSettingVisible);
 export const isLeftHalfPairing = createSelector(advanceSettingsState, fromAdvancedSettings.isLeftHalfPairing);
 export const getIsI2cDebuggingEnabled = createSelector(advanceSettingsState, fromAdvancedSettings.isI2cDebuggingEnabled);
 export const isI2cDebuggingRingBellEnabled = createSelector(advanceSettingsState, fromAdvancedSettings.isI2cDebuggingRingBellEnabled);

--- a/packages/uhk-web/src/app/store/reducers/advanced-settings.reducer.ts
+++ b/packages/uhk-web/src/app/store/reducers/advanced-settings.reducer.ts
@@ -25,7 +25,6 @@ export enum ActiveButton {
 export interface State {
     activeButton: ActiveButton;
     alwaysEnableAdvancedMode: boolean;
-    alwaysEnableAdvancedModeSettingVisible: boolean;
     i2cDebuggingRingBellEnabled: boolean,
     i2cLogs: Array<XtermLog>;
     isLeftHalfPairing: boolean;
@@ -40,7 +39,6 @@ export interface State {
 export const initialState = (): State => ({
     activeButton: ActiveButton.None,
     alwaysEnableAdvancedMode: false,
-    alwaysEnableAdvancedModeSettingVisible: false,
     i2cDebuggingRingBellEnabled: false,
     i2cLogs: [],
     isDongleZephyrLoggingEnabled: false,
@@ -61,8 +59,6 @@ export function reducer(state = initialState(), action: Actions | App.Actions | 
             return {
                 ...state,
                 alwaysEnableAdvancedMode,
-                alwaysEnableAdvancedModeSettingVisible: alwaysEnableAdvancedMode
-                    || state.alwaysEnableAdvancedModeSettingVisible,
                 menuVisible: alwaysEnableAdvancedMode || state.menuVisible,
             };
         }
@@ -231,7 +227,6 @@ export function reducer(state = initialState(), action: Actions | App.Actions | 
             return {
                 ...state,
                 menuVisible: true,
-                alwaysEnableAdvancedModeSettingVisible: true,
             };
         }
 
@@ -241,7 +236,6 @@ export function reducer(state = initialState(), action: Actions | App.Actions | 
             return {
                 ...state,
                 alwaysEnableAdvancedMode,
-                alwaysEnableAdvancedModeSettingVisible: true,
                 menuVisible: alwaysEnableAdvancedMode || state.menuVisible,
             };
         }
@@ -271,8 +265,6 @@ export function reducer(state = initialState(), action: Actions | App.Actions | 
 
 export const isAdvancedSettingsMenuVisible = (state: State): boolean => state.menuVisible;
 export const isAlwaysEnableAdvancedMode = (state: State): boolean => state.alwaysEnableAdvancedMode;
-export const isAlwaysEnableAdvancedModeSettingVisible = (state: State): boolean =>
-    state.menuVisible || state.alwaysEnableAdvancedModeSettingVisible;
 export const isLeftHalfPairing = (state: State): boolean => state.isLeftHalfPairing;
 export const isI2cDebuggingEnabled = (state: State): boolean => state.activeButton === ActiveButton.I2CRecoveryDebugging;
 export const isI2cDebuggingRingBellEnabled = (state: State): boolean => state.i2cDebuggingRingBellEnabled;

--- a/packages/uhk-web/src/app/store/reducers/advanced-settings.reducer.ts
+++ b/packages/uhk-web/src/app/store/reducers/advanced-settings.reducer.ts
@@ -9,6 +9,7 @@ import {
     IsDongleZephyrLoggingEnabledReplyAction,
     IsLeftHalfZephyrLoggingEnabledReplyAction,
     IsRightHalfZephyrLoggingEnabledReplyAction,
+    ToggleAlwaysEnableAdvancedModeAction,
     ZephyrLogAction,
 } from '../actions/advance-settings.action';
 import * as App from '../actions/app';
@@ -23,6 +24,8 @@ export enum ActiveButton {
 
 export interface State {
     activeButton: ActiveButton;
+    alwaysEnableAdvancedMode: boolean;
+    alwaysEnableAdvancedModeSettingVisible: boolean;
     i2cDebuggingRingBellEnabled: boolean,
     i2cLogs: Array<XtermLog>;
     isLeftHalfPairing: boolean;
@@ -36,6 +39,8 @@ export interface State {
 
 export const initialState = (): State => ({
     activeButton: ActiveButton.None,
+    alwaysEnableAdvancedMode: false,
+    alwaysEnableAdvancedModeSettingVisible: false,
     i2cDebuggingRingBellEnabled: false,
     i2cLogs: [],
     isDongleZephyrLoggingEnabled: false,
@@ -48,6 +53,19 @@ export const initialState = (): State => ({
 
 export function reducer(state = initialState(), action: Actions | App.Actions | Device.Actions) {
     switch (action.type) {
+
+        case App.ActionTypes.LoadApplicationSettingsSuccess: {
+            const settings = (action as App.LoadApplicationSettingsSuccessAction).payload;
+            const alwaysEnableAdvancedMode = !!settings.alwaysEnableAdvancedMode;
+
+            return {
+                ...state,
+                alwaysEnableAdvancedMode,
+                alwaysEnableAdvancedModeSettingVisible: alwaysEnableAdvancedMode
+                    || state.alwaysEnableAdvancedModeSettingVisible,
+                menuVisible: alwaysEnableAdvancedMode || state.menuVisible,
+            };
+        }
 
         case App.ActionTypes.ElectronMainLogReceived: {
             if (!state.isLeftHalfPairing) {
@@ -212,7 +230,19 @@ export function reducer(state = initialState(), action: Actions | App.Actions | 
         case ActionTypes.showAdvancedSettingsMenu: {
             return {
                 ...state,
-                menuVisible: true
+                menuVisible: true,
+                alwaysEnableAdvancedModeSettingVisible: true,
+            };
+        }
+
+        case ActionTypes.toggleAlwaysEnableAdvancedMode: {
+            const alwaysEnableAdvancedMode = (action as ToggleAlwaysEnableAdvancedModeAction).payload;
+
+            return {
+                ...state,
+                alwaysEnableAdvancedMode,
+                alwaysEnableAdvancedModeSettingVisible: true,
+                menuVisible: alwaysEnableAdvancedMode || state.menuVisible,
             };
         }
 
@@ -240,6 +270,9 @@ export function reducer(state = initialState(), action: Actions | App.Actions | 
 }
 
 export const isAdvancedSettingsMenuVisible = (state: State): boolean => state.menuVisible;
+export const isAlwaysEnableAdvancedMode = (state: State): boolean => state.alwaysEnableAdvancedMode;
+export const isAlwaysEnableAdvancedModeSettingVisible = (state: State): boolean =>
+    state.menuVisible || state.alwaysEnableAdvancedModeSettingVisible;
 export const isLeftHalfPairing = (state: State): boolean => state.isLeftHalfPairing;
 export const isI2cDebuggingEnabled = (state: State): boolean => state.activeButton === ActiveButton.I2CRecoveryDebugging;
 export const isI2cDebuggingRingBellEnabled = (state: State): boolean => state.i2cDebuggingRingBellEnabled;


### PR DESCRIPTION
## Summary
- Adds a persisted **Always enable advanced settings** checkbox to Agent Settings.
- When checked, the Advanced settings menu stays visible across Agent restarts.
- The checkbox is only shown after advanced mode is unlocked (About logo easter egg), or once it has been checked during the current session.

Closes #2970

## Test plan
- [ ] Click the About logo 7 times to unlock Advanced settings
- [ ] Open Agent → Settings and verify the new checkbox appears
- [ ] Check **Always enable advanced settings**, restart Agent, and confirm Advanced settings remains in the sidebar
- [ ] Uncheck the setting, restart Agent, and confirm Advanced settings is hidden again until unlocked

Made with [Cursor](https://cursor.com)