### PR TITLE
fix: improve name persistence.

### DIFF
--- a/packages/uhk-common/src/config-serializer/config-items/user-configuration.ts
+++ b/packages/uhk-common/src/config-serializer/config-items/user-configuration.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { DEFAULT_DEVICE_NAME } from '../../util/constants.js';
 import { assertEnum, assertFloat, assertInt16, assertUInt16, assertUInt32, assertUInt8 } from '../assert.js';
 import { resolveSwitchKeymapActions } from '../resolve-switch-keymap-actions.js';
 import { UhkBuffer } from '../uhk-buffer.js';
@@ -537,7 +538,7 @@ export class UserConfiguration implements AdvancedSecondaryRoleConfiguration, Mo
 
     private setDefaultDeviceName(): void {
         if (!this.deviceName || this.deviceName.trim().length === 0) {
-            this.deviceName = 'My UHK';
+            this.deviceName = DEFAULT_DEVICE_NAME;
         }
     }
 

--- a/packages/uhk-common/src/util/constants.ts
+++ b/packages/uhk-common/src/util/constants.ts
@@ -4,5 +4,7 @@ export const AGENT_CONTRIBUTORS_GITHUB_API_URL = 'https://api.github.com/repos/U
 export const MAX_ALLOWED_MACROS = 255;
 export const MAX_ALLOWED_MACROS_TOOLTIP = `No more than ${MAX_ALLOWED_MACROS} macros are supported.`;
 
+export const DEFAULT_DEVICE_NAME = 'My UHK';
+
 export const UHK_EEPROM_SIZE = 32768;
 export const ERR_UPDATER_INVALID_SIGNATURE = 'ERR_UPDATER_INVALID_SIGNATURE'

--- a/packages/uhk-web/src/app/store/effects/user-config.ts
+++ b/packages/uhk-web/src/app/store/effects/user-config.ts
@@ -10,6 +10,7 @@ import { saveAs } from 'file-saver';
 import {
     BackupUserConfigurationInfo,
     Buffer,
+    DEFAULT_DEVICE_NAME,
     getHardwareConfigFromDeviceResponse,
     getUserConfigFromDeviceResponse,
     ConfigurationReply,
@@ -337,7 +338,9 @@ export class UserConfigEffects {
 
                         // Keep the connected keyboard's name when importing a config, so a single config
                         // can be shared across multiple keyboards while each retains its own name.
-                        userConfig.deviceName = deviceName;
+                        if (deviceName !== DEFAULT_DEVICE_NAME) {
+                            userConfig.deviceName = deviceName;
+                        }
 
                         if (payload.autoSave) {
                             return new ApplyUserConfigurationFromFileAction({


### PR DESCRIPTION
At the moment, name is overwritten by the unbricking functionalities, and then the default name is kept persistent during UserConfig imports. Allow importing name when current name is the default string.