### PR TITLE
fix: add some margin to macro edit page

### DIFF
--- a/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.scss
+++ b/packages/uhk-web/src/app/components/macro/edit/macro-edit.component.scss
@@ -28,7 +28,7 @@
 
 .macro-container-wrapper {
     position: relative;
-    height: 100%;
+    min-height: 100%;
     border-right: solid 1px var(--color-smart-macro-border-color);
 }
 

--- a/packages/uhk-web/src/app/components/macro/list/macro-list.component.scss
+++ b/packages/uhk-web/src/app/components/macro/list/macro-list.component.scss
@@ -8,6 +8,7 @@
         display: flex;
         flex: 1;
         justify-content: center;
+        padding-bottom: 2em;
 
         .list-wrapper {
             width: 90%;


### PR DESCRIPTION
This PR addressing 2 issues
- Add some margin to the bottom of the marco edit page. It helps to more easily click on the macro `Save` button when the `Save to keyboard` button is visible See: https://github.com/UltimateHackingKeyboard/firmware/issues/1595#issuecomment-4945795548
- Draw the thin line of the `Smart macro reference` panel to the bottom of the page . Mainly visible in dark mode. See the screenshot

<img width="1716" height="885" alt="Screenshot 2026-07-14 at 12 27 14" src="https://github.com/user-attachments/assets/8d4b6d40-cb2d-4ace-abef-96da75c2f0c1" />
