### PR TITLE
feat: expand macro field limits according to user configuration data types

### DIFF
--- a/packages/uhk-common/src/config-serializer/assert.ts
+++ b/packages/uhk-common/src/config-serializer/assert.ts
@@ -1,31 +1,41 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+export const INT8_MIN = -0x80;
+export const INT8_MAX = 0x7F;
+export const INT16_MIN = -0x8000;
+export const INT16_MAX = 0x7FFF;
+export const INT32_MIN = -0x80000000;
+export const INT32_MAX = 0x7FFFFFFF;
+export const UINT8_MAX = 0xFF;
+export const UINT16_MAX = 0xFFFF;
+export const UINT32_MAX = 0xFFFFFFFF;
+
 export function assertUInt8(target: any, key: string) {
-    return assertInteger(target, key, 0, 0xFF);
+    return assertInteger(target, key, 0, UINT8_MAX);
 }
 
 export function assertInt8(target: any, key: string) {
-    return assertInteger(target, key, -0x80, 0x7F);
+    return assertInteger(target, key, INT8_MIN, INT8_MAX);
 }
 
 export function assertUInt16(target: any, key: string) {
-    return assertInteger(target, key, 0, 0xFFFF);
+    return assertInteger(target, key, 0, UINT16_MAX);
 }
 
 export function assertInt16(target: any, key: string) {
-    return assertInteger(target, key, -0x8000, 0x7FFF);
+    return assertInteger(target, key, INT16_MIN, INT16_MAX);
 }
 
 export function assertUInt32(target: any, key: string) {
-    return assertInteger(target, key, 0, 0xFFFFFFFF);
+    return assertInteger(target, key, 0, UINT32_MAX);
 }
 
 export function assertInt32(target: any, key: string) {
-    return assertInteger(target, key, -0x80000000, 0x7FFFFFFF);
+    return assertInteger(target, key, INT32_MIN, INT32_MAX);
 }
 
 export function assertFloat(target: any, key: string) {
-    return assertInteger(target, key, -0x80000000, 0x7FFFFFFF);
+    return assertInteger(target, key, INT32_MIN, INT32_MAX);
 }
 
 export function assertCompactLength(target: any, key: string) {

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.html
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.html
@@ -15,7 +15,7 @@
                        placeholder="Delay amount"
                        class="form-control"
                        [ngModel]="delay"
-                       (ngModelChange)="setDelay(macroDelayInput.value)">
+                       (ngModelChange)="setDelay(macroDelayInput.valueAsNumber)">
                 seconds
             </div>
         </div>

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.html
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.html
@@ -10,7 +10,7 @@
                 <input #macroDelayInput
                        type="number"
                        min="0"
-                       max="65"
+                       [max]="maxDelaySeconds"
                        step="0.1"
                        placeholder="Delay amount"
                        class="form-control"

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.ts
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.ts
@@ -4,11 +4,12 @@ import {
     Input,
     OnInit
 } from '@angular/core';
-import { DelayMacroAction } from 'uhk-common';
+import { DelayMacroAction, UINT16_MAX } from 'uhk-common';
 
 import { MacroBaseComponent } from '../macro-base.component';
 
 const INITIAL_DELAY = 0.5; // In seconds
+const MAX_DELAY_SECONDS = UINT16_MAX / 1000;
 
 @Component({
     selector: 'macro-delay-tab',
@@ -21,6 +22,7 @@ const INITIAL_DELAY = 0.5; // In seconds
 export class MacroDelayTabComponent extends MacroBaseComponent implements OnInit {
     @Input() macroAction: DelayMacroAction;
 
+    maxDelaySeconds = MAX_DELAY_SECONDS;
     presets: number[] = [0.1, 0.5, 1, 5, 10];
 
     get delay(): number {
@@ -44,8 +46,9 @@ export class MacroDelayTabComponent extends MacroBaseComponent implements OnInit
     }
 
     setDelay(value: number): void {
-        this._delay = Math.min(value, 65);
-        this.macroAction.delay = this._delay * 1000;
+        const delayMs = Math.min(Math.max(Math.round(value * 1000), 0), UINT16_MAX);
+        this._delay = delayMs / 1000;
+        this.macroAction.delay = delayMs;
         this.validate();
     }
 

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.ts
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.ts
@@ -46,6 +46,10 @@ export class MacroDelayTabComponent extends MacroBaseComponent implements OnInit
     }
 
     setDelay(value: number): void {
+        if (Number.isNaN(value)) {
+            return;
+        }
+
         const delayMs = Math.min(Math.max(Math.round(value * 1000), 0), UINT16_MAX);
         this._delay = delayMs / 1000;
         this.macroAction.delay = delayMs;

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.ts
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/delay/macro-delay.component.ts
@@ -51,11 +51,10 @@ export class MacroDelayTabComponent extends MacroBaseComponent implements OnInit
         }
 
         const delayMs = Math.min(Math.max(Math.round(value * 1000), 0), UINT16_MAX);
-        this._delay = delayMs / 1000;
         this.macroAction.delay = delayMs;
-        this.validate();
+        this.delay = delayMs / 1000;
     }
 
-    isMacroValid = () => this.macroAction.delay !== 0;
+    isMacroValid = () => this.macroAction.delay > 0 && this.macroAction.delay <= UINT16_MAX;
 
 }

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/mouse/macro-mouse.component.html
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/mouse/macro-mouse.component.html
@@ -42,22 +42,22 @@
                     <input id="move-mouse-x"
                            type="number"
                            class="form-control"
-                           [(ngModel)]="macroAction['x']"
-                           (ngModelChange)="validate()"
-                           min="-9999"
-                           max="9999"
-                           maxlength="4"> pixels
+                           [ngModel]="macroAction['x']"
+                           (ngModelChange)="setCoordinate('x', $event)"
+                           [min]="INT16_MIN"
+                           [max]="INT16_MAX"
+                           maxlength="6"> pixels
                 </div>
                 <div class="mb-2">
                     <label for="move-mouse-y">Y:</label>
                     <input id="move-mouse-y"
                            type="number"
                            class="form-control"
-                           [(ngModel)]="macroAction['y']"
-                           (ngModelChange)="validate()"
-                           min="-9999"
-                           max="9999"
-                           maxlength="4"> pixels
+                           [ngModel]="macroAction['y']"
+                           (ngModelChange)="setCoordinate('y', $event)"
+                           [min]="INT16_MIN"
+                           [max]="INT16_MAX"
+                           maxlength="6"> pixels
                 </div>
             </div>
         </div>
@@ -69,22 +69,22 @@
                     <input id="scroll-mouse-x"
                            type="number"
                            class="form-control"
-                           [(ngModel)]="macroAction['x']"
-                           (ngModelChange)="validate()"
-                           min="-9999"
-                           max="9999"
-                           maxlength="4"> pixels
+                           [ngModel]="macroAction['x']"
+                           (ngModelChange)="setCoordinate('x', $event)"
+                           [min]="INT16_MIN"
+                           [max]="INT16_MAX"
+                           maxlength="6"> pixels
                 </div>
                 <div class="mb-2">
                     <label for="scroll-mouse-y">Y:</label>
                     <input id="scroll-mouse-y"
                            type="number"
                            class="form-control"
-                           [(ngModel)]="macroAction['y']"
-                           (ngModelChange)="validate()"
-                           min="-9999"
-                           max="9999"
-                           maxlength="4"> pixels
+                           [ngModel]="macroAction['y']"
+                           (ngModelChange)="setCoordinate('y', $event)"
+                           [min]="INT16_MIN"
+                           [max]="INT16_MAX"
+                           maxlength="6"> pixels
                 </div>
             </div>
         </div>

--- a/packages/uhk-web/src/app/components/macro/action-editor/tab/mouse/macro-mouse.component.ts
+++ b/packages/uhk-web/src/app/components/macro/action-editor/tab/mouse/macro-mouse.component.ts
@@ -2,6 +2,8 @@ import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { faArrowsAlt, faArrowsAltV, faHandPaper, faHandRock, faMousePointer } from '@fortawesome/free-solid-svg-icons';
 
 import {
+    INT16_MAX,
+    INT16_MIN,
     MacroMouseSubAction,
     MouseButtons,
     MouseButtonMacroAction,
@@ -33,6 +35,8 @@ enum TabName {
 export class MacroMouseTabComponent extends MacroBaseComponent implements OnInit, OnChanges {
     @Input() macroAction: MouseMacroAction;
 
+    INT16_MAX = INT16_MAX;
+    INT16_MIN = INT16_MIN;
     MouseButtons = MouseButtons;
     TabName = TabName;
     activeTab: TabName;
@@ -114,6 +118,17 @@ export class MacroMouseTabComponent extends MacroBaseComponent implements OnInit
         }
     }
 
+    setCoordinate(axis: 'x' | 'y', value: number | string): void {
+        const numericValue = Number(value);
+        if (Number.isNaN(numericValue)) {
+            return;
+        }
+
+        const action = this.macroAction as MoveMouseMacroAction | ScrollMouseMacroAction;
+        action[axis] = Math.min(Math.max(Math.round(numericValue), INT16_MIN), INT16_MAX);
+        this.validate();
+    }
+
     getTabName(action: MouseMacroAction): TabName {
         if (action instanceof MouseButtonMacroAction) {
             if (!action.action || action.isOnlyClickAction()) {
@@ -137,7 +152,9 @@ export class MacroMouseTabComponent extends MacroBaseComponent implements OnInit
             case ScrollMouseMacroAction: {
                 const { x, y } = this.macroAction as MoveMouseMacroAction;
                 return x !== undefined && x !== null && y !== undefined && y !== null &&
-                    (x !== 0 || y !== 0) && x < 10000 && x > -10000 && y < 10000 && y > -10000;
+                    (x !== 0 || y !== 0) &&
+                    x >= INT16_MIN && x <= INT16_MAX &&
+                    y >= INT16_MIN && y <= INT16_MAX;
             }
 
             case MouseButtonMacroAction: {


### PR DESCRIPTION
## Summary
- Export integer range constants from the config serializer and use them in the macro editor.
- Expand mouse move/scroll coordinate limits from ±9999 to the Int16 range (±32767).
- Expand delay limit from 65 s to 65.535 s (UInt16 milliseconds).
- Clamp out-of-range coordinate input so values like 80000 are corrected immediately.

Fixes #2754

## Test plan
- [ ] In a move-pointer macro action, enter `80000` for X or Y and confirm it clamps to `32767`.
- [ ] Enter `-40000` and confirm it clamps to `-32768`.
- [ ] Enter a delay of `100` seconds and confirm it clamps to `65.535`.
- [ ] Save the macro and verify the configuration still serializes correctly.


Made with [Cursor](https://cursor.com)