### PR TITLE
Show which keymap is currently active on the keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 Every Agent version includes the most recent firmware version. See the [firmware changelog](https://github.com/UltimateHackingKeyboard/firmware/blob/master/CHANGELOG.md).
 
+## [Unreleased]
+
+- Show which keymap is currently active on the keyboard in the sidebar, and mark inactive keymaps in the header. `DEVICEPROTOCOL:MINOR`
+
 ## [10.1.0] - 2026-06-23
 
 Firmware: 17.2.0 [[release](https://github.com/UltimateHackingKeyboard/firmware/releases/tag/v17.2.0)] | Device Protocol: 4.17.0 | User Config: 14.0.0 | Hardware Config: 1.0.0

--- a/packages/uhk-common/src/models/device-connection-state.ts
+++ b/packages/uhk-common/src/models/device-connection-state.ts
@@ -9,6 +9,10 @@ export interface DeviceConnectionState {
     // UHK80 connected via bluetooth
     bleDeviceConnected: boolean;
     isPairedWithDongle?: boolean;
+    /**
+     * Index of the keymap currently active on the keyboard (GetDeviceState byte 8).
+     */
+    activeKeymapIndex?: number;
     connectedDevice?: UhkDeviceProduct;
     dongle: Dongle;
     leftHalfBootloaderActive: boolean;

--- a/packages/uhk-common/src/util/index.ts
+++ b/packages/uhk-common/src/util/index.ts
@@ -12,6 +12,7 @@ export * from './get-md5-hash-from-file-name.js';
 export * from './get-slot-id-name.js';
 export * from './helpers.js';
 export * from './is-bit-set.js';
+export * from './is-device-protocol-support-active-keymap-index.js';
 export * from './is-device-protocol-support-firmware-checksum.js';
 export * from './is-device-protocol-support-git-info.js';
 export * from './is-device-protocol-support-status-error.js';

--- a/packages/uhk-common/src/util/is-device-protocol-support-active-keymap-index.ts
+++ b/packages/uhk-common/src/util/is-device-protocol-support-active-keymap-index.ts
@@ -1,0 +1,7 @@
+import { isVersionGteV1CanUndefined } from './version-helpers.js';
+
+const DEVICE_PROTOCOL_VERSION_THAT_SUPPORT_ACTIVE_KEYMAP_INDEX = '4.10.0';
+
+export function isDeviceProtocolSupportActiveKeymapIndex(deviceProtocolVersion: string): boolean {
+    return isVersionGteV1CanUndefined(deviceProtocolVersion, DEVICE_PROTOCOL_VERSION_THAT_SUPPORT_ACTIVE_KEYMAP_INDEX);
+}

--- a/packages/uhk-usb/src/models/device-state.ts
+++ b/packages/uhk-usb/src/models/device-state.ts
@@ -4,6 +4,7 @@ export interface DeviceState {
     isZephyrLogAvailable: boolean;
     areHalvesMerged: boolean;
     isLeftHalfConnected: boolean;
+    activeKeymapIndex: number;
     activeLayerNumber: number;
     activeLayerName: string;
     activeLayerToggled: boolean;

--- a/packages/uhk-usb/src/uhk-hid-device.ts
+++ b/packages/uhk-usb/src/uhk-hid-device.ts
@@ -405,6 +405,7 @@ export class UhkHidDevice {
 
         if (result.connectedDevice && result.hasPermission && result.communicationInterfaceAvailable) {
             const deviceState = await this.getDeviceState();
+            result.activeKeymapIndex = deviceState.activeKeymapIndex;
             result.halvesInfo = calculateHalvesState(deviceState);
             result.isMacroStatusDirty = deviceState.isMacroStatusDirty;
             result.isZephyrLogAvailable = deviceState.isZephyrLogAvailable;
@@ -623,6 +624,7 @@ export class UhkHidDevice {
             isMacroStatusDirty: buffer[7] !== 0,
             areHalvesMerged: isBitSet(buffer[2], 0),
             isLeftHalfConnected: buffer[3] !== 0,
+            activeKeymapIndex: buffer[8],
             activeLayerNumber,
             activeLayerName: LAYER_NUMBER_TO_STRING[activeLayerNumber],
             activeLayerToggled: (buffer[6] & 0x80) === 1,

--- a/packages/uhk-web/src/app/components/keymap/edit/keymap-edit.component.html
+++ b/packages/uhk-web/src/app/components/keymap/edit/keymap-edit.component.html
@@ -1,6 +1,7 @@
 <ng-template [ngIf]="keymap">
     <keymap-header [keymap]="keymap"
                    [deletable]="deletable$ | async"
+                   [inactiveKeymapTooltip]="(inactiveKeymapTooltip$ | async) || ''"
     ></keymap-header>
     <svg-keyboard-wrap [keymap]="keymap"
                        [halvesInfo]="halvesInfo$ | async"

--- a/packages/uhk-web/src/app/components/keymap/edit/keymap-edit.component.ts
+++ b/packages/uhk-web/src/app/components/keymap/edit/keymap-edit.component.ts
@@ -23,6 +23,7 @@ import {
     getSecondaryRoleOptions,
     getSelectedKeymap,
     getSelectedLayerOption,
+    inactiveKeymapTooltip,
     isBacklightingColoring,
     isKeymapDeletable,
     lastEditedKey,
@@ -73,6 +74,7 @@ export class KeymapEditComponent implements OnDestroy {
     secondaryRoleOptions$: Observable<SelectOptionData[]>;
     selectedPaletteColorIndex$: Observable<number>;
     showColorPalette$: Observable<boolean>;
+    inactiveKeymapTooltip$: Observable<string>;
 
     private routeSubscription: Subscription;
     private keymapSubscription: Subscription;
@@ -134,6 +136,7 @@ export class KeymapEditComponent implements OnDestroy {
         this.showColorPalette$ = this.store.select(showColorPalette);
         this.paletteColors$ = this.store.select(backlightingColorPalette);
         this.selectedPaletteColorIndex$ = this.store.select(selectedBacklightingColorIndex);
+        this.inactiveKeymapTooltip$ = this.store.select(inactiveKeymapTooltip);
     }
 
     ngOnDestroy(): void {

--- a/packages/uhk-web/src/app/components/keymap/header/keymap-header.component.html
+++ b/packages/uhk-web/src/app/components/keymap/header/keymap-header.component.html
@@ -18,6 +18,12 @@
                  placement="bottom"
                  (click)="setDefault()"
         ></fa-icon>
+        <span *ngIf="inactiveKeymapTooltip"
+              class="text-muted"
+              [ngbTooltip]="inactiveKeymapTooltip"
+              tooltipClass="tooltip-inactive-keymap"
+              container="body"
+              placement="bottom">(inactive)</span>
         <fa-icon [icon]="faTrash"
                  [ngbTooltip]="trashTitle"
                  tooltipClass="tooltip-nowrap"

--- a/packages/uhk-web/src/app/components/keymap/header/keymap-header.component.ts
+++ b/packages/uhk-web/src/app/components/keymap/header/keymap-header.component.ts
@@ -41,6 +41,7 @@ export class KeymapHeaderComponent implements OnChanges, OnDestroy {
 
     @Input() keymap: Keymap;
     @Input() deletable: boolean;
+    @Input() inactiveKeymapTooltip = '';
 
     @ViewChild('abbr', { static: true }) keymapAbbr: ElementRef<HTMLInputElement>;
     @ViewChild(AutoGrowInputComponent, { static: true }) keymapName: AutoGrowInputComponent;

--- a/packages/uhk-web/src/app/components/side-menu/side-menu.component.html
+++ b/packages/uhk-web/src/app/components/side-menu/side-menu.component.html
@@ -189,10 +189,16 @@
                              (click)="toggleMenuItem('keymap')"></fa-icon>
                 </div>
                 <ul [@toggler]="this.sideMenuState.keymap.animation">
-                    <li *ngFor="let keymap of state.keymaps" class="sidebar__level-2--item">
+                    <li *ngFor="let keymap of state.keymaps; let keymapIndex = index" class="sidebar__level-2--item">
                         <div class="sidebar__level-2" [class.active]="state.selectedKeymap?.abbreviation === keymap.abbreviation">
                             <a [routerLink]="['/keymap', keymap.abbreviation]" [queryParams]="state.keymapQueryParams"
                                [class.disabled]="state.updatingFirmware">{{keymap.name}}</a>
+                            <fa-icon *ngIf="state.activeKeymapIndex === keymapIndex"
+                                     [icon]="faCircle"
+                                     class="sidebar__active-keymap"
+                                     ngbTooltip="This is the keymap currently active on the keyboard. The star marks the default keymap that activates when powering the keyboard."
+                                     container="body"
+                                     placement="bottom"></fa-icon>
                             <fa-icon *ngIf="keymap.isDefault"
                                      [icon]="faStar"
                                      class="sidebar__fav"

--- a/packages/uhk-web/src/app/components/side-menu/side-menu.component.scss
+++ b/packages/uhk-web/src/app/components/side-menu/side-menu.component.scss
@@ -118,7 +118,8 @@ ul {
                     color: var(--color-sidemenu-active-text);
                 }
 
-                .fa-star {
+                .fa-star,
+                .sidebar__active-keymap {
                     color: var(--color-sidemenu-active-text);
                 }
 
@@ -225,6 +226,18 @@ ul {
         right: 19px;
         top: 3px;
         z-index: 50;
+    }
+
+    &__active-keymap {
+        font-size: 0.55rem;
+        position: absolute;
+        right: 19px;
+        top: 6px;
+        z-index: 50;
+    }
+
+    &__level-2:has(.sidebar__active-keymap) .sidebar__fav {
+        right: 34px;
     }
 
     &__macro_count {

--- a/packages/uhk-web/src/app/components/side-menu/side-menu.component.ts
+++ b/packages/uhk-web/src/app/components/side-menu/side-menu.component.ts
@@ -16,6 +16,7 @@ import {
     faChevronDown,
     faChevronRight,
     faChevronUp,
+    faCircle,
     faCog,
     faExclamationTriangle,
     faInfoCircle,
@@ -100,6 +101,7 @@ export class SideMenuComponent implements OnChanges, OnInit, OnDestroy {
             animation: 'active'
         }
     };
+    faCircle = faCircle;
     faCog = faCog;
     faExclamationTriangle = faExclamationTriangle;
     faInfoCircle = faInfoCircle;

--- a/packages/uhk-web/src/app/models/side-menu-page-state.ts
+++ b/packages/uhk-web/src/app/models/side-menu-page-state.ts
@@ -10,6 +10,7 @@ export interface SideMenuPageState {
     runInElectron: boolean;
     updatingFirmware: boolean;
     deviceName: string;
+    activeKeymapIndex?: number;
     keymaps: Keymap[];
     keymapQueryParams: Params;
     macroTree: MacroMenuTreeNode[];

--- a/packages/uhk-web/src/app/store/index.ts
+++ b/packages/uhk-web/src/app/store/index.ts
@@ -13,6 +13,7 @@ import {
     HardwareModules,
     HistoryFileInfo as CommonHistoryFileInfo,
     HostConnections,
+    isDeviceProtocolSupportActiveKeymapIndex,
     isVersionGt,
     isVersionGteV1CanUndefined,
     Keymap,
@@ -312,6 +313,44 @@ export const getHalvesInfo = createSelector(deviceState, fromDevice.halvesInfo);
 export const isUserConfigSaving = createSelector(deviceState, fromDevice.isUserConfigSaving);
 export const deviceUiState = createSelector(deviceState, fromDevice.deviceUiState);
 export const getConnectedDevice = createSelector(deviceState, fromDevice.getConnectedDevice);
+export const getActiveKeymapIndex = createSelector(
+    deviceState,
+    getHardwareModules,
+    (state, hardwareModules): number | undefined => {
+        if (!isDeviceProtocolSupportActiveKeymapIndex(hardwareModules.rightModuleInfo?.deviceProtocolVersion)) {
+            return undefined;
+        }
+
+        return fromDevice.getActiveKeymapIndex(state);
+    }
+);
+export const inactiveKeymapTooltip = createSelector(
+    runningInElectron,
+    getUserConfiguration,
+    getSelectedKeymap,
+    getActiveKeymapIndex,
+    (electron, userConfiguration, selectedKeymap, activeKeymapIndex): string => {
+        if (!electron || activeKeymapIndex === undefined || !selectedKeymap) {
+            return '';
+        }
+
+        const selectedKeymapIndex = userConfiguration.keymaps
+            .findIndex(keymap => keymap.abbreviation === selectedKeymap.abbreviation);
+
+        if (selectedKeymapIndex === -1 || selectedKeymapIndex === activeKeymapIndex) {
+            return '';
+        }
+
+        const activeKeymapName = userConfiguration.keymaps[activeKeymapIndex]?.name;
+
+        if (!activeKeymapName) {
+            return '';
+        }
+
+        return `This keymap is not currently active on the keyboard. ` +
+            `The sidebar dot marks the active keymap, which is currently ${activeKeymapName}.`;
+    }
+);
 export const getSkipFirmwareUpgrade = createSelector(deviceState, fromDevice.getSkipFirmwareUpgrade);
 export const isKeyboardLayoutChanging = createSelector(deviceState, fromDevice.isKeyboardLayoutChanging);
 export const keyboardHalvesAlwaysJoined = createSelector(deviceState, fromDevice.keyboardHalvesAlwaysJoined);
@@ -582,6 +621,7 @@ export const getSideMenuPageState = createSelector(
     getRestoreUserConfiguration,
     calculateDeviceUiState,
     getConnectedDevice,
+    getActiveKeymapIndex,
     getIsAdvancedSettingsMenuVisible,
     getSelectedLayerOption,
     getDonglePairingState,
@@ -597,6 +637,7 @@ export const getSideMenuPageState = createSelector(
         restoreUserConfiguration: boolean,
         uiState,
         connectedDevice,
+        activeKeymapIndex,
         isAdvancedSettingsMenuVisible,
         selectedLayerOption,
         donglePairingState,
@@ -615,6 +656,7 @@ export const getSideMenuPageState = createSelector(
             runInElectron: runningInElectronValue,
             updatingFirmware: updatingFirmwareValue || donglePairingState.operation !== DongleOperations.None || leftHalfPairing,
             deviceName: userConfiguration.deviceName,
+            activeKeymapIndex: runningInElectronValue ? activeKeymapIndex : undefined,
             keymaps: userConfiguration.keymaps,
             keymapQueryParams: {
                 layer: selectedLayerOption.id

--- a/packages/uhk-web/src/app/store/reducers/device.ts
+++ b/packages/uhk-web/src/app/store/reducers/device.ts
@@ -32,6 +32,7 @@ export interface State {
     dongle?: Dongle;
     isKeyboardLayoutChanging: boolean;
     isPairedWithDongle?: boolean;
+    activeKeymapIndex?: number;
     connectedDevice: UhkDeviceProduct;
     hasPermission: boolean;
     hideStatusBufferError: boolean;
@@ -154,6 +155,7 @@ export function reducer(state = initialState, action: Action): State {
                 bleDeviceConnected: data.bleDeviceConnected,
                 dongle: data.dongle,
                 isPairedWithDongle: data.isPairedWithDongle,
+                activeKeymapIndex: data.activeKeymapIndex,
                 connectedDevice: data.connectedDevice,
                 deviceConnectionStateLoaded: true,
                 hasPermission: data.hasPermission,
@@ -467,6 +469,7 @@ export const deviceUiState = (state: State): DeviceUiStates | undefined => {
 };
 
 export const getConnectedDevice = (state: State) => state.connectedDevice;
+export const getActiveKeymapIndex = (state: State) => state.activeKeymapIndex;
 export const getHostConnectionPairState = (state: State): Record<string, boolean> => state.hostConnectionPairState;
 export const getLeftHalfDetected = (state: State) => state.leftHalfDetected;
 export const getSkipFirmwareUpgrade = (state: State) => state.skipFirmwareUpgrade;

--- a/packages/uhk-web/src/styles/_global.scss
+++ b/packages/uhk-web/src/styles/_global.scss
@@ -285,6 +285,11 @@ kbd {
     max-width: 320px;
 }
 
+.tooltip-inactive-keymap .tooltip-inner {
+    width: 320px;
+    max-width: 320px;
+}
+
 mwl-confirmation-popover-window {
     .popover {
         &.bottom {

--- a/packages/usb/get-device-state.ts
+++ b/packages/usb/get-device-state.ts
@@ -20,6 +20,7 @@ newPairedDevice: ${state.newPairedDevice ? 'yes' : 'no'} | \
 leftKeyboardHalfSlot:${state.leftKeyboardHalfSlot} | \
 leftModuleSlot:${state.leftModuleSlot} | \
 rightModuleSlot:${state.rightModuleSlot} | \
+keymapIndex:${state.activeKeymapIndex} | \
 layer:${state.activeLayerName} ${state.activeLayerToggled ? 'toggled' : ''}`
         );
     } catch (error) {


### PR DESCRIPTION
## Summary
- Parse `CurrentKeymapIndex` from `GetDeviceState` (byte 8) and surface it through the device poller
- Show a sidebar dot on the live keymap and an `(inactive)` label in the keymap header when editing a different one
- Gate the UI on device protocol ≥ 4.10.0; update `get-device-state.ts` to print `keymapIndex`

Closes #2560

## Test plan
- [ ] With firmware that supports device protocol ≥ 4.10.0, confirm the sidebar dot tracks the keyboard’s active keymap as you switch keymaps on the device
- [ ] Open a non-active keymap and confirm `(inactive)` appears in the header with a tooltip naming the active keymap and mentioning the sidebar dot
- [ ] Open the active keymap and confirm `(inactive)` is hidden
- [ ] Confirm the default ★ and active dot can appear together without overlapping awkwardly
- [ ] Run `packages/usb/get-device-state.ts` and confirm `keymapIndex` is printed
- [ ] On older device protocol (< 4.10.0), confirm the dot and `(inactive)` are not shown


Made with [Cursor](https://cursor.com)