### PR TITLE
Improve keyboard accessibility for remapping controls

### DIFF
--- a/packages/uhk-web/src/app/components/editable-text/editable-text.component.html
+++ b/packages/uhk-web/src/app/components/editable-text/editable-text.component.html
@@ -1,16 +1,15 @@
 <div class="text-center">
-    <span *ngIf="showPlaceholder"
-          class="placeholder">
-        <span (click)="editText()">{{ placeholder }}</span>
-    </span>
+    <button *ngIf="showPlaceholder"
+            type="button"
+            class="btn btn-link p-0 text-center placeholder editable-text__trigger"
+            (click)="editText()">{{ placeholder }}</button>
 
-    <span *ngIf="showText"
-          class="editable">
-        <span (click)="editText()"
-        >
+    <button *ngIf="showText"
+            type="button"
+            class="btn btn-link p-0 text-center editable editable-text__trigger"
+            (click)="editText()">
             <ng-container *ngFor="let line of displayLines">{{line}}<br></ng-container>
-        </span>
-    </span>
+    </button>
 </div>
 
 <div *ngIf="editing">

--- a/packages/uhk-web/src/app/components/editable-text/editable-text.component.scss
+++ b/packages/uhk-web/src/app/components/editable-text/editable-text.component.scss
@@ -1,7 +1,7 @@
 :host {
     margin-top: 0.5em;
 
-    span.placeholder {
+    .placeholder {
         color: gray;
         display: inline-block;
 
@@ -10,9 +10,15 @@
         }
     }
 
-    span.editable,
-    span.placeholder {
+    .editable,
+    .placeholder {
         cursor: pointer;
+    }
+
+    .editable-text__trigger {
+        color: inherit;
+        text-decoration: none;
+        white-space: normal;
     }
 
     textarea.text-editor {

--- a/packages/uhk-web/src/app/components/macro/header/macro-header.component.html
+++ b/packages/uhk-web/src/app/components/macro/header/macro-header.component.html
@@ -4,19 +4,26 @@
                      maxParentWidthPercent="0.8"
                      [selectAfterInit]="isNew"
                      (ngModelChange)="editMacroName($event)"></auto-grow-input>
-    <fa-icon [icon]="faTrash"
-             class="macro__remove float-end"
-             ngbTooltip="Delete macro"
-             tooltipClass="tooltip-nowrap"
-             placement="bottom-right"
-             (click)="removeMacro()"></fa-icon>
-    <fa-icon [icon]="faCopy"
-             class="macro__duplicate float-end"
-             [class.disabled]="maxMacroCountReached"
-             [ngbTooltip]="maxMacroCountReached ? maxAllowedMacrosTooltip : 'Duplicate macro'"
-             tooltipClass="tooltip-nowrap"
-             placement="bottom-right"
-             (click)="duplicateMacro()"></fa-icon>
+    <button type="button"
+            class="macro__remove float-end btn btn-link p-0"
+            aria-label="Delete macro"
+            ngbTooltip="Delete macro"
+            tooltipClass="tooltip-nowrap"
+            placement="bottom-right"
+            (click)="removeMacro()">
+        <fa-icon [icon]="faTrash"></fa-icon>
+    </button>
+    <button type="button"
+            class="macro__duplicate float-end btn btn-link p-0"
+            [class.disabled]="maxMacroCountReached"
+            [disabled]="maxMacroCountReached"
+            aria-label="Duplicate macro"
+            [ngbTooltip]="maxMacroCountReached ? maxAllowedMacrosTooltip : 'Duplicate macro'"
+            tooltipClass="tooltip-nowrap"
+            placement="bottom-right"
+            (click)="duplicateMacro()">
+        <fa-icon [icon]="faCopy"></fa-icon>
+    </button>
 </uhk-header>
 <div *ngIf="assignments.length" class="mt-3 mb-2">
     <span class="me-1">Used on:</span>

--- a/packages/uhk-web/src/app/components/macro/header/macro-header.component.scss
+++ b/packages/uhk-web/src/app/components/macro/header/macro-header.component.scss
@@ -3,6 +3,9 @@
         font-size: 0.75em;
         top: 7px;
         position: relative;
+        color: inherit;
+        text-decoration: none;
+        border: 0;
 
         &:hover {
             cursor: pointer;
@@ -15,6 +18,9 @@
         top: 7px;
         margin-right: 15px;
         position: relative;
+        color: inherit;
+        text-decoration: none;
+        border: 0;
 
         &:hover:not(.disabled) {
             cursor: pointer;

--- a/packages/uhk-web/src/app/components/macro/item/macro-item.component.html
+++ b/packages/uhk-web/src/app/components/macro/item/macro-item.component.html
@@ -3,16 +3,33 @@
         <i *ngIf="movable"
            class="uhk-icon uhk-icon-vertical-grip-icon action--movable"
            aria-hidden="true"></i>
-        <div class="action--item--wrap" [class.pointer]="editable" (click)="editAction()">
+        <button type="button"
+                class="action--item--wrap"
+                [class.pointer]="editable"
+                [disabled]="!editable"
+                aria-label="Edit macro action"
+                (click)="editAction()">
             <icon [name]="iconName" class="align-items-top"></icon>
             <div class="action--title">
                 {{ title }}
                 <svg-sprite-image *ngIf="titleIcon" [icon]="titleIcon"></svg-sprite-image>
             </div>
             <icon *ngIf="editable && macroAction && !editing" name="pencil" class="align-items-top"></icon>
-        </div>
-        <icon *ngIf="editable" name="copy" (click)="duplicateAction()" class="align-items-top"></icon>
-        <icon *ngIf="deletable" name="trash" (click)="deleteAction()" class="align-items-top"></icon>
+        </button>
+        <button *ngIf="editable"
+                type="button"
+                class="action--item--icon-button"
+                aria-label="Duplicate macro action"
+                (click)="duplicateAction()">
+            <icon name="copy" class="align-items-top"></icon>
+        </button>
+        <button *ngIf="deletable"
+                type="button"
+                class="action--item--icon-button"
+                aria-label="Delete macro action"
+                (click)="deleteAction()">
+            <icon name="trash" class="align-items-top"></icon>
+        </button>
     </ng-container>
 
     <div *ngIf="isCommand && !editing" class="macro-command-item">
@@ -25,9 +42,27 @@
 
             <span class="pe-1 me-auto">Command:</span>
 
-            <icon *ngIf="editable" name="pencil" (click)="editAction()"></icon>
-            <icon *ngIf="editable" name="copy" (click)="duplicateAction()"></icon>
-            <icon *ngIf="deletable" name="trash" (click)="deleteAction()"></icon>
+            <button *ngIf="editable"
+                    type="button"
+                    class="action--item--icon-button"
+                    aria-label="Edit macro action"
+                    (click)="editAction()">
+                <icon name="pencil"></icon>
+            </button>
+            <button *ngIf="editable"
+                    type="button"
+                    class="action--item--icon-button"
+                    aria-label="Duplicate macro action"
+                    (click)="duplicateAction()">
+                <icon name="copy"></icon>
+            </button>
+            <button *ngIf="deletable"
+                    type="button"
+                    class="action--item--icon-button"
+                    aria-label="Delete macro action"
+                    (click)="deleteAction()">
+                <icon name="trash"></icon>
+            </button>
         </div>
         <div class="macro-command-editor-container">
             <macro-command-editor [ngModel]="macroAction.command"

--- a/packages/uhk-web/src/app/components/macro/item/macro-item.component.scss
+++ b/packages/uhk-web/src/app/components/macro/item/macro-item.component.scss
@@ -54,14 +54,46 @@
         }
 
         &--wrap {
+            display: flex;
+            flex: 1;
             justify-content: space-between;
             padding-top: 0.25rem;
+            width: 100%;
+            border: 0;
+            outline: 0;
+            box-shadow: none;
+            appearance: none;
+            background: transparent;
+            color: inherit;
+            text-align: left;
 
             &.pointer {
                 &:hover {
                     cursor: pointer;
                     color: var(--color-icon-hover);
                 }
+            }
+
+            &:focus-visible {
+                outline: 2px solid var(--color-icon-hover);
+                outline-offset: 2px;
+            }
+        }
+
+        &--icon-button {
+            border: 0;
+            outline: 0;
+            box-shadow: none;
+            appearance: none;
+            background: transparent;
+            color: inherit;
+            padding: 0;
+            flex: 0 0 auto;
+            align-items: flex-start;
+
+            &:focus-visible {
+                outline: 2px solid var(--color-icon-hover);
+                outline-offset: 2px;
             }
         }
 

--- a/packages/uhk-web/src/app/components/popover/popover.component.html
+++ b/packages/uhk-web/src/app/components/popover/popover.component.html
@@ -3,18 +3,23 @@
 >
     <div class="arrowCustom"></div>
     <div class="popover-title menu-tabs">
-        <ul class="nav nav-tabs popover-menu">
+        <ul class="nav nav-tabs popover-menu" role="tablist">
             <li *ngFor="let tab of tabHeaders; trackBy:trackTabHeader"
                 class="nav-item"
                 [class.active]="activeTab === tab.tabName"
-                [class.disabled]="tab.disabled"
-                (click)="selectTab(tab)">
-                <a class="nav-link menu-tabs--item"
+                [class.disabled]="tab.disabled">
+                <button class="nav-link menu-tabs--item"
+                    type="button"
+                    role="tab"
                     [class.active]="activeTab === tab.tabName"
-                    [class.disabled]="tab.disabled">
+                    [class.disabled]="tab.disabled"
+                    [attr.aria-selected]="activeTab === tab.tabName"
+                    [attr.tabindex]="activeTab === tab.tabName ? 0 : -1"
+                    [disabled]="tab.disabled"
+                    (click)="selectTab(tab)">
                     <fa-icon [icon]="tab.icon"></fa-icon>
                     <span>{{ tab.text }}</span>
-                </a>
+                </button>
             </li>
         </ul>
     </div>

--- a/packages/uhk-web/src/app/components/popover/popover.component.scss
+++ b/packages/uhk-web/src/app/components/popover/popover.component.scss
@@ -90,7 +90,7 @@
                     position: relative;
                     z-index: 2;
 
-                    a.active {
+                    .menu-tabs--item.active {
                         border-bottom: 1px solid var(--color-popover-bg-light);
                     }
                 }
@@ -99,6 +99,7 @@
             .menu-tabs--item {
                 display: flex;
                 align-items: center;
+                width: 100%;
 
                 fa-icon {
                     margin-right: 0.25em;

--- a/packages/uhk-web/src/app/components/popover/tab/macro/macro-tab.component.html
+++ b/packages/uhk-web/src/app/components/popover/tab/macro/macro-tab.component.html
@@ -31,15 +31,16 @@
                 </td>
                 <td class="col-controls">
                     <button class="btn btn-link" type="button" (click)="navigateToMacro.emit()"
+                       aria-label="Jump to selected macro"
                        ngbTooltip="Jump to macro">
                         <fa-icon [icon]="faUpRightFromSquare"
                                  aria-hidden="true"></fa-icon>
                     </button>
-                    <button class="btn btn-default" [class.active]="showMacroArguments" (click)="toggleMacroArguments()" [ngbTooltip]="showMacroArgumentsTooltip" type="button" [attr.aria-pressed]="showMacroArguments">
+                    <button class="btn btn-default" [class.active]="showMacroArguments" (click)="toggleMacroArguments()" [ngbTooltip]="showMacroArgumentsTooltip" type="button" [attr.aria-pressed]="showMacroArguments" aria-label="Toggle macro arguments">
                         <fa-icon [icon]="faBracketsWithDots"
                                  aria-hidden="true" />
                     </button>
-                    <button class="btn btn-default" (click)="assignNewMacro.emit()" ngbTooltip="Create new macro for this key" type="button">
+                    <button class="btn btn-default" (click)="assignNewMacro.emit()" ngbTooltip="Create new macro for this key" type="button" aria-label="Create new macro for this key">
                         <fa-icon [icon]="faPlus"
                                  aria-hidden="true"></fa-icon>
                     </button>
@@ -53,16 +54,19 @@
                     <input type="text" class="form-control" [ngModel]="macroArgument.value" (ngModelChange)="onMacroArgumentChange($event, i)">
                 </td>
                 <td class="col-controls arguments">
-                    <fa-icon [icon]="faCircleMinus"
-                             aria-hidden="true"
-                             role="button"
-                             (click)="removeMacroArgument(i)"
-                    />
-                    <fa-icon *ngIf="last" [icon]="faCirclePlus"
-                             aria-hidden="true"
-                             role="button"
-                             (click)="addNewMacroArgument()"
-                    />
+                    <button type="button"
+                            class="btn btn-link p-0"
+                            aria-label="Remove macro argument"
+                            (click)="removeMacroArgument(i)">
+                        <fa-icon [icon]="faCircleMinus" aria-hidden="true" />
+                    </button>
+                    <button *ngIf="last"
+                            type="button"
+                            class="btn btn-link p-0"
+                            aria-label="Add macro argument"
+                            (click)="addNewMacroArgument()">
+                        <fa-icon [icon]="faCirclePlus" aria-hidden="true" />
+                    </button>
                 </td>
             </tr>
         </tbody>

--- a/packages/uhk-web/src/app/components/side-menu/side-menu.component.html
+++ b/packages/uhk-web/src/app/components/side-menu/side-menu.component.html
@@ -10,9 +10,14 @@
                                  [css]="'side-menu-pane-title__name'"
                                  [disabled]="state.restoreUserConfiguration || state.updatingFirmware"
                                  (ngModelChange)="editDeviceName($event)"></auto-grow-input>
-                <fa-icon [icon]="this.sideMenuState.device.icon"
-                         class="chevron float-end"
-                         (click)="toggleMenuItem('device')"></fa-icon>
+                <button type="button"
+                        class="btn btn-link p-0 chevron float-end"
+                        [attr.aria-expanded]="sideMenuState.device.animation === 'active'"
+                        aria-controls="side-menu-device-section"
+                        aria-label="Toggle device section"
+                        (click)="toggleMenuItem('device')">
+                    <fa-icon [icon]="this.sideMenuState.device.icon"></fa-icon>
+                </button>
             </ng-container>
 
             <a *ngSwitchCase="'MultiDevice'"
@@ -63,16 +68,21 @@
                 {{ state?.connectedDevice?.name }}
             </a>
         </div>
-        <ul [@toggler]="this.sideMenuState.device.animation">
+        <ul id="side-menu-device-section" [@toggler]="this.sideMenuState.device.animation">
             <li class="sidebar__level-1--item">
                 <div class="sidebar__level-1">
                     <fa-icon [icon]="faSlidersH"></fa-icon>
                     Device
-                    <fa-icon [icon]="this.sideMenuState.configuration.icon"
-                             class="chevron float-end"
-                             (click)="toggleMenuItem('configuration')"></fa-icon>
+                    <button type="button"
+                            class="btn btn-link p-0 chevron float-end"
+                            [attr.aria-expanded]="sideMenuState.configuration.animation === 'active'"
+                            aria-controls="side-menu-configuration-section"
+                            aria-label="Toggle configuration section"
+                            (click)="toggleMenuItem('configuration')">
+                        <fa-icon [icon]="this.sideMenuState.configuration.icon"></fa-icon>
+                    </button>
                 </div>
-                <ul [@toggler]="this.sideMenuState.configuration.animation">
+                <ul id="side-menu-configuration-section" [@toggler]="this.sideMenuState.configuration.animation">
                     <li class="sidebar__level-2--item"
                         *ngIf="!state.restoreUserConfiguration">
                         <div class="sidebar__level-2" [routerLinkActive]="['active']">
@@ -142,11 +152,16 @@
                 <div class="sidebar__level-1">
                     <fa-icon [icon]="faPuzzlePiece"></fa-icon>
                     Modules
-                    <fa-icon [icon]="this.sideMenuState.addon.icon"
-                             class="chevron float-end"
-                             (click)="toggleMenuItem('addon')"></fa-icon>
+                    <button type="button"
+                            class="btn btn-link p-0 chevron float-end"
+                            [attr.aria-expanded]="sideMenuState.addon.animation === 'active'"
+                            aria-controls="side-menu-addon-section"
+                            aria-label="Toggle modules section"
+                            (click)="toggleMenuItem('addon')">
+                        <fa-icon [icon]="this.sideMenuState.addon.icon"></fa-icon>
+                    </button>
                 </div>
-                <ul [@toggler]="this.sideMenuState.addon.animation">
+                <ul id="side-menu-addon-section" [@toggler]="this.sideMenuState.addon.animation">
                     <li class="sidebar__level-2--item" data-name="Key cluster" data-abbrev="">
                         <div class="sidebar__level-2" [routerLinkActive]="['active']">
                             <a [routerLink]="['/add-on', 'key-cluster']"
@@ -184,11 +199,16 @@
                        [class.disabled]="state.updatingFirmware">
                         <fa-icon [icon]="faPlus"></fa-icon>
                     </a>
-                    <fa-icon [icon]="this.sideMenuState.keymap.icon"
-                             class="chevron float-end me-1"
-                             (click)="toggleMenuItem('keymap')"></fa-icon>
+                    <button type="button"
+                            class="btn btn-link p-0 chevron float-end me-1"
+                            [attr.aria-expanded]="sideMenuState.keymap.animation === 'active'"
+                            aria-controls="side-menu-keymap-section"
+                            aria-label="Toggle keymaps section"
+                            (click)="toggleMenuItem('keymap')">
+                        <fa-icon [icon]="this.sideMenuState.keymap.icon"></fa-icon>
+                    </button>
                 </div>
-                <ul [@toggler]="this.sideMenuState.keymap.animation">
+                <ul id="side-menu-keymap-section" [@toggler]="this.sideMenuState.keymap.animation">
                     <li *ngFor="let keymap of state.keymaps; let keymapIndex = index" class="sidebar__level-2--item">
                         <div class="sidebar__level-2" [class.active]="state.selectedKeymap?.abbreviation === keymap.abbreviation">
                             <a [routerLink]="['/keymap', keymap.abbreviation]" [queryParams]="state.keymapQueryParams"
@@ -223,11 +243,16 @@
                                  container="body"
                         ></fa-icon>
                     </button>
-                    <fa-icon [icon]="this.sideMenuState.macro.icon"
-                             class="chevron float-end me-1"
-                             (click)="toggleMenuItem('macro')"></fa-icon>
+                    <button type="button"
+                            class="btn btn-link p-0 chevron float-end me-1"
+                            [attr.aria-expanded]="sideMenuState.macro.animation === 'active'"
+                            aria-controls="side-menu-macro-section"
+                            aria-label="Toggle macros section"
+                            (click)="toggleMenuItem('macro')">
+                        <fa-icon [icon]="this.sideMenuState.macro.icon"></fa-icon>
+                    </button>
                 </div>
-                <ul class="sidebar__macro-tree" [@toggler]="this.sideMenuState.macro.animation">
+                <ul id="side-menu-macro-section" class="sidebar__macro-tree" [@toggler]="this.sideMenuState.macro.animation">
                     <ng-container *ngTemplateOutlet="macroTree; context: { $implicit: state.macroTree }"></ng-container>
                 </ul>
             </li>
@@ -248,13 +273,17 @@
             </div>
         </li>
         <li *ngIf="node.type === 'group'" class="sidebar__macro-tree-item">
-            <div class="sidebar__macro-tree-entry sidebar__macro-group"
-                 (click)="toggleMacroGroup(node.path)">
-                {{ node.label }}…
+            <button type="button"
+                    class="sidebar__macro-tree-entry sidebar__macro-group"
+                    [attr.aria-expanded]="getMacroGroupState(node.path).animation === 'active'"
+                    [attr.aria-controls]="'macro-group-' + node.path"
+                    [attr.aria-label]="'Toggle macro group ' + node.label"
+                    (click)="toggleMacroGroup(node.path)">
+                <span>{{ node.label }}…</span>
                 <fa-icon [icon]="getMacroGroupArrowIcon(node.path)"
                          class="sidebar__macro-group-arrow"></fa-icon>
-            </div>
-            <ul class="sidebar__macro-group-children" [@toggler]="getMacroGroupState(node.path).animation">
+            </button>
+            <ul [id]="'macro-group-' + node.path" class="sidebar__macro-group-children" [@toggler]="getMacroGroupState(node.path).animation">
                 <ng-container *ngTemplateOutlet="macroTree; context: { $implicit: node.children }"></ng-container>
             </ul>
         </li>

--- a/packages/uhk-web/src/app/components/side-menu/side-menu.component.scss
+++ b/packages/uhk-web/src/app/components/side-menu/side-menu.component.scss
@@ -74,7 +74,13 @@ ul {
 
         &:hover {
             .chevron {
-                display: inline-block;
+                opacity: 1;
+            }
+        }
+
+        &:focus-within {
+            .chevron {
+                opacity: 1;
             }
         }
 
@@ -89,8 +95,12 @@ ul {
         .chevron {
             line-height: $font-size-lg * 1.7;
             font-size: $font-size-lg * 0.75;
-            display: none;
+            display: inline-block;
+            opacity: 0;
             cursor: pointer;
+            color: inherit;
+            text-decoration: none;
+            border: 0;
         }
 
         .btn + .chevron {
@@ -195,9 +205,16 @@ ul {
     &__macro-group {
         cursor: pointer;
         font-weight: 500;
+        width: 100%;
+        border: 0;
+        background: transparent;
+        color: inherit;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        text-align: left;
 
         &-arrow {
-            float: right;
             font-size: 0.65rem;
             line-height: inherit;
             margin-right: 0.25rem;

--- a/packages/uhk-web/src/app/components/svg/keys/svg-keyboard-key/svg-keyboard-key.component.scss
+++ b/packages/uhk-web/src/app/components/svg/keys/svg-keyboard-key/svg-keyboard-key.component.scss
@@ -2,3 +2,9 @@
     cursor: pointer;
     outline: none;
 }
+
+:host(:focus),
+:host(:focus-visible) {
+    outline: none;
+    box-shadow: none;
+}

--- a/packages/uhk-web/src/app/components/svg/keys/svg-keyboard-key/svg-keyboard-key.component.ts
+++ b/packages/uhk-web/src/app/components/svg/keys/svg-keyboard-key/svg-keyboard-key.component.ts
@@ -125,6 +125,7 @@ export class SvgKeyboardKeyComponent implements OnChanges, OnDestroy {
     recordAnimation: string;
     recording: boolean;
     labelType: LabelTypes;
+    accessibleLabel = 'Unassigned key';
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     labelSource: any;
@@ -140,6 +141,7 @@ export class SvgKeyboardKeyComponent implements OnChanges, OnDestroy {
     private layerOptionMap = initLayerOptions();
     private isMouseMoveDispatched = false;
     private isMouseHover = false;
+    private isFocused = false;
 
     constructor(
         private sanitizer: DomSanitizer,
@@ -170,6 +172,17 @@ export class SvgKeyboardKeyComponent implements OnChanges, OnDestroy {
         return this.fillColor;
     }
 
+    @HostBinding('attr.role')
+    readonly role = 'button';
+
+    @HostBinding('attr.tabindex')
+    readonly tabIndex = 0;
+
+    @HostBinding('attr.aria-label')
+    get ariaLabel(): string {
+        return this.accessibleLabel;
+    }
+
     @HostBinding('attr.fill')
     get fill(): SafeStyle {
         return this.fillColor;
@@ -182,7 +195,7 @@ export class SvgKeyboardKeyComponent implements OnChanges, OnDestroy {
 
     @HostBinding('attr.stroke-width')
     get strokeWidth(): SafeStyle {
-        return this.isActive ? '3' : '1';
+        return this.isActive || this.isFocused ? '3' : '1';
     }
 
     @HostBinding('style')
@@ -199,20 +212,51 @@ export class SvgKeyboardKeyComponent implements OnChanges, OnDestroy {
 
     @HostListener('click', ['$event'])
     onClick(e: MouseEvent) {
+        this.activateKey(e.shiftKey, e.altKey, false);
+    }
+
+    @HostListener('keydown', ['$event'])
+    onHostKeyDown(e: KeyboardEvent) {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            this.activateKey(e.shiftKey, e.altKey, true);
+        }
+    }
+
+    @HostListener('focus')
+    onFocus() {
+        this.isFocused = true;
+        this.setColors();
+    }
+
+    @HostListener('blur')
+    onBlur() {
+        this.isFocused = false;
+        this.setColors();
+    }
+
+    private activateKey(shiftPressed: boolean, altPressed: boolean, keyboardTriggered: boolean) {
         this.reset();
         this.keyClick.emit({
             keyTarget: this.element.nativeElement,
-            shiftPressed: e.shiftKey,
-            altPressed: e.altKey
+            keyboardTriggered,
+            shiftPressed,
+            altPressed
         });
         this.pressedShiftLocation = -1;
         this.pressedAltLocation = -1;
+
+        if (!keyboardTriggered) {
+            setTimeout(() => this.element.nativeElement.blur());
+        }
     }
 
     @HostListener('mousedown', ['$event'])
     onMouseDown(e: MouseEvent) {
 
         if ((e.which === 0 || e.button === 0)) {
+            e.preventDefault();
             this.mouseMoveService.leftButtonDown();
             this.dragAndDropService.leftButtonDown({
                 keyId: this.svgKey.id,
@@ -410,6 +454,7 @@ export class SvgKeyboardKeyComponent implements OnChanges, OnDestroy {
         this.labelType = LabelTypes.OneLineText;
         this.labelSource = undefined;
         this.secondaryText = undefined;
+        this.accessibleLabel = 'Unassigned key';
 
         if (!this.keyAction) {
             return;
@@ -566,6 +611,8 @@ export class SvgKeyboardKeyComponent implements OnChanges, OnDestroy {
         } else {
             this.labelSource = undefined;
         }
+
+        this.accessibleLabel = this.buildAccessibleLabel();
     }
 
     private blinkSvgRec(): void {
@@ -600,13 +647,79 @@ export class SvgKeyboardKeyComponent implements OnChanges, OnDestroy {
                     : themeColors.selectedKeyColor2;
             } else if (this.isMouseHover && !this.mouseMoveService.isColoring) {
                 this.fillColor = colors.hoverColorAsHex;
+                if (this.isFocused) {
+                    this.strokeColor = themeColors.selectedKeyColor;
+                }
+            } else if (this.isFocused) {
+                this.strokeColor = themeColors.selectedKeyColor;
             }
         } else {
             if (this.isActive) {
                 this.fillColor = 'var(--color-keyboard-key-active)';
             } else if (this.isMouseHover) {
                 this.fillColor = 'var(--color-keyboard-key-hover)';
+                if (this.isFocused) {
+                    this.strokeColor = themeColors.selectedKeyColor;
+                }
+            } else if (this.isFocused) {
+                this.strokeColor = themeColors.selectedKeyColor;
             }
         }
+    }
+
+    private buildAccessibleLabel(): string {
+        if (!this.keyAction) {
+            return 'Unassigned key';
+        }
+
+        if (this.keyAction instanceof KeystrokeAction) {
+            const parts: string[] = [];
+
+            if (this.keyAction.hasActiveModifier()) {
+                parts.push(this.keyAction.getModifierList().join(' + '));
+            }
+
+            if (this.keyAction.hasScancode()) {
+                parts.push(this.mapper.scanCodeToText(this.keyAction.scancode, this.keyAction.type).join(' '));
+            }
+
+            if (parts.length === 0) {
+                parts.push('Keystroke');
+            }
+
+            if (this.keyAction.hasSecondaryRoleAction()) {
+                parts.push(`secondary role ${this.mapper.getSecondaryRoleText(this.keyAction.secondaryRoleAction)}`);
+            }
+
+            return parts.join(', ');
+        }
+
+        if (this.keyAction instanceof SwitchLayerAction) {
+            const layerName = this.layerOptionMap.get(this.keyAction.layer)?.name || 'unknown';
+            return `Switch to ${layerName} layer`;
+        }
+
+        if (this.keyAction instanceof SwitchKeymapAction) {
+            return `Switch to keymap ${this.keyAction.keymapAbbreviation}`;
+        }
+
+        if (this.keyAction instanceof PlayMacroAction) {
+            const macroName = this.macroMap.get(this.keyAction.macroId)?.name;
+            return macroName ? `Play macro ${macroName}` : 'Play macro';
+        }
+
+        if (this.keyAction instanceof MouseAction) {
+            return 'Mouse action';
+        }
+
+        if (this.keyAction instanceof ConnectionsAction) {
+            return 'Host connection action';
+        }
+
+        if (this.keyAction instanceof OtherAction) {
+            return 'Other action';
+        }
+
+        return 'Assigned key action';
     }
 }

--- a/packages/uhk-web/src/app/components/svg/module/svg-module.component.html
+++ b/packages/uhk-web/src/app/components/svg/module/svg-module.component.html
@@ -27,7 +27,6 @@
             [svgKey]="key"
             [backlightingMode]="backlightingMode"
             [isActive]="selected && i === selectedKey.keyId"
-            tabindex="-1"
             [keyAction]="keyActions && keyActions[i]"
             [capturingEnabled]="capturingEnabled"
             [hostConnections]="hostConnections"

--- a/packages/uhk-web/src/app/components/svg/wrap/svg-keyboard-wrap.component.ts
+++ b/packages/uhk-web/src/app/components/svg/wrap/svg-keyboard-wrap.component.ts
@@ -152,6 +152,7 @@ export class SvgKeyboardWrapComponent implements AfterViewInit, OnInit, OnChange
 
     private wrapHost: HTMLElement;
     private keyElement: HTMLElement;
+    private restoreFocusAfterPopoverClose = false;
     private animationSubscription = new Subscription();
     private openPopoverSubscription = new Subscription();
 
@@ -241,6 +242,8 @@ export class SvgKeyboardWrapComponent implements AfterViewInit, OnInit, OnChange
     }
 
     onKeyClick(event: SvgKeyboardKeyClickEvent): void {
+        this.restoreFocusAfterPopoverClose = !!event.keyboardTriggered;
+
         if (this.isBacklightingColoring) {
             this.store.dispatch(new SetKeyColorAction({
                 keymap: this.keymap,
@@ -372,9 +375,17 @@ export class SvgKeyboardWrapComponent implements AfterViewInit, OnInit, OnChange
     }
 
     hidePopover(): void {
+        const keyElementToRefocus = this.animationState === 'opened' && this.restoreFocusAfterPopoverClose
+            ? this.keyElement
+            : undefined;
         this.animationState = 'closed';
         this.selectedKey = undefined;
         this.popoverInitKeyAction = null;
+        this.restoreFocusAfterPopoverClose = false;
+
+        if (keyElementToRefocus) {
+            setTimeout(() => keyElementToRefocus.focus());
+        }
     }
 
     onDescriptionChanged(description: string): void {

--- a/packages/uhk-web/src/app/components/user-configuration-history/user-configuration-history.component.html
+++ b/packages/uhk-web/src/app/components/user-configuration-history/user-configuration-history.component.html
@@ -23,18 +23,18 @@
                 confirmText="Yes"
                 cancelText="No"
                 [isOpen]="showDeleteUserConfigHistoryPopoverIndex === index"
-                (click)="onSelectTab(index)"
                 (contextmenu)="onTabContextmenuClick(index)"
                 (confirm)="deleteUserConfigHistory.emit(tab.deviceUniqueId)"
                 (isOpenChange)="onDeletePopoverOpenChange($event, index)"
             >
-                <a class="nav-link"
-                   [class.active]="state.selectedTabIndex === index"
-                   [class.fw-bold]="tab.isCurrentDevice"
-                   [attr.title]="tab.tooltip"
-                >
+                <button type="button"
+                        class="nav-link"
+                        [class.active]="state.selectedTabIndex === index"
+                        [class.fw-bold]="tab.isCurrentDevice"
+                        [attr.title]="tab.tooltip"
+                        (click)="onSelectTab(index)">
                     <span>{{ tab.displayText }}</span>
-                </a>
+                </button>
            </li>
         </ul>
 
@@ -45,12 +45,13 @@
                         {{ fileInfo.timestamp }}
                     </span>
 
-                    <span class="btn btn-link btn-padding-0"
-                          *ngIf="fileInfo.showRestore"
-                          (click)="getUserConfigFromHistory.emit(fileInfo.file)"
-                          [class.disabled]="state.disabled">
-                                {{ fileInfo.displayText }}
-                    </span>
+                    <button type="button"
+                            class="btn btn-link btn-padding-0"
+                            *ngIf="fileInfo.showRestore"
+                            (click)="getUserConfigFromHistory.emit(fileInfo.file)"
+                            [disabled]="state.disabled">
+                        {{ fileInfo.displayText }}
+                    </button>
 
                     <span class="btn btn-link btn-padding-0 current"
                           *ngIf="!fileInfo.showRestore">
@@ -69,12 +70,13 @@
                     {{ fileInfo.timestamp }}
                 </span>
 
-                <span class="btn btn-link btn-padding-0"
-                      *ngIf="fileInfo.showRestore"
-                      (click)="getUserConfigFromHistory.emit(fileInfo.file)"
-                      [class.disabled]="state.disabled">
-                            {{ fileInfo.displayText }}
-                </span>
+                <button type="button"
+                        class="btn btn-link btn-padding-0"
+                        *ngIf="fileInfo.showRestore"
+                        (click)="getUserConfigFromHistory.emit(fileInfo.file)"
+                        [disabled]="state.disabled">
+                    {{ fileInfo.displayText }}
+                </button>
 
                 <span class="btn btn-link btn-padding-0 current"
                       *ngIf="!fileInfo.showRestore">

--- a/packages/uhk-web/src/app/models/svg-key-events.ts
+++ b/packages/uhk-web/src/app/models/svg-key-events.ts
@@ -4,6 +4,7 @@ import { KeyModifierModel } from './key-modifier-model';
 
 export interface SvgKeyClickEvent {
     keyTarget: HTMLElement;
+    keyboardTriggered?: boolean;
     shiftPressed?: boolean;
     altPressed?: boolean;
 }


### PR DESCRIPTION
## Summary
- replace click-only controls in the Agent UI with real buttons so keyboard and screen reader users can activate tabs, expanders, and icon actions without relying on the mouse
- make SVG keyboard keys focusable and activatable with `Enter`/`Space`, with screen-reader labels and focus restoration for keyboard-triggered remap flows
- leave the Phase 3 linting/reduced-motion follow-up out of this PR so the user-facing accessibility fixes stay isolated

## Test plan
- [x] Run `npm run lint --scope=uhk-web`
- [ ] Verify key remap popovers can be opened from the SVG keyboard with keyboard focus plus `Enter`/`Space`
- [ ] Verify click-only macro, popover, and side-menu controls remain visually correct and keyboard-activatable
- [ ] Smoke test with macOS VoiceOver and standard keyboard navigation

Made with [Cursor](https://cursor.com)