### PR TITLE
fix(uhk-agent): make smart-macro dest writable around fs.cp

### DIFF
--- a/packages/uhk-agent/src/services/smart-macro-doc.service.ts
+++ b/packages/uhk-agent/src/services/smart-macro-doc.service.ts
@@ -56,9 +56,19 @@ export class SmartMacroDocService {
         try {
             this.logService.misc(serviceLogMessage('starting...'));
             const firmwarePathData = getDefaultFirmwarePath(this.rootDir);
-            await copySmartMacroDocToWebserver(firmwarePathData, this.logService);
-            await copySmartMacroLoadingHtml(this.rootDir, this.logService);
-            await makeFolderWriteableToUserOnLinux(getSmartMacroDocRootPath());
+            // Bundled smart-macro docs are optional for keymap editing. A copy
+            // failure (e.g. EACCES against a leftover read-only tree from an
+            // immutable install prefix) must not abort createWindow().
+            try {
+                await copySmartMacroDocToWebserver(firmwarePathData, this.logService);
+                await copySmartMacroLoadingHtml(this.rootDir, this.logService);
+                await makeFolderWriteableToUserOnLinux(getSmartMacroDocRootPath());
+            } catch (err) {
+                this.logService.error(
+                    serviceLogMessage('documentation setup failed; continuing without bundled smart-macro docs'),
+                    err
+                );
+            }
             this.logService.misc(serviceLogMessage('get free TCP port'));
             this.port = await getPort();
             this.logService.misc(serviceLogMessage(`acquired TCP port: ${this.port}`));

--- a/packages/uhk-agent/src/util/copy-smart-macro-doc-to-webserver.ts
+++ b/packages/uhk-agent/src/util/copy-smart-macro-doc-to-webserver.ts
@@ -1,9 +1,11 @@
 import { cp } from 'fs/promises';
 import path from 'path';
 import { LogService } from 'uhk-common';
+import { pathExists } from 'uhk-fs';
 import {getFirmwarePackageJson,TmpFirmware} from 'uhk-usb';
 
 import { getSmartMacroDocRootPath } from './get-smart-macro-doc-root-path';
+import { makeFolderWriteableToUserOnLinux } from './make-folder-writeable-to-user-on-linux';
 
 export async function copySmartMacroDocToWebserver(firmwarePath: TmpFirmware, logger: LogService): Promise<void> {
     logger.misc('[SmartMacroCopy] start');
@@ -22,7 +24,20 @@ export async function copySmartMacroDocToWebserver(firmwarePath: TmpFirmware, lo
         smartMacroDocFirmwarePath
     });
 
+    // fs.cp preserves source directory modes. When the install prefix is
+    // immutable (e.g. the Nix store, mode 0555), the first copy creates
+    // `destination` as dr-xr-xr-x. A prior failed run can also leave such a
+    // tree behind. Make an existing destination writable before force-copy
+    // so unlink of its contents cannot EACCES, then make it writable again
+    // before the nested doc-dev copy which needs to mkdir inside it.
+    // See UltimateHackingKeyboard/agent#2652, #2679 and PR #2680.
+    if (await pathExists(destination)) {
+        await makeFolderWriteableToUserOnLinux(destination);
+    }
+
     await cp(smartMacroDocFirmwarePath, destination, { force: true, recursive: true });
+
+    await makeFolderWriteableToUserOnLinux(destination);
 
     const referenceManualFirmwarePath = path.join(firmwarePath.tmpDirectory, 'doc-dev');
     const referenceManualDestination = path.join(destination, 'doc-dev');


### PR DESCRIPTION
## Summary

`copySmartMacroDocToWebserver` (`SmartMacroCopy`) uses Node's `fs.cp({ force, recursive })` from the install prefix into `~/.config/uhk-agent/smart-macro-docs/...`. `fs.cp` preserves source directory modes when it creates the destination. On any install whose prefix is immutable (the Nix store is the known case — directories are mode `0555`), the first copy leaves the destination as `dr-xr-xr-x`.

Current order:

1. `cp(doc → destination)` — creates `destination` with source modes (`0555`)
2. `cp(doc-dev → destination/doc-dev)` — needs write on `destination` → **EACCES mkdir**
3. Later, outside this function: `makeFolderWriteableToUserOnLinux(smart-macro-root)` (`chmod -R +w`)

Step 3 never runs when step 2 throws. On the next launch, step 1's `force` unlink hits the leftover `0555` directory → **EACCES unlink**. Either failure becomes an unhandled rejection in `createWindow` (`await smartMacroDocService.start()`), so the main `BrowserWindow` is never constructed — live process, no window.

This is **not NixOS-specific**. Any read-only install prefix triggers the same mode preservation. The existing post-copy `chmod` is correct in intent but ordered too late.

## Changes

1. **`copy-smart-macro-doc-to-webserver.ts`**
   - If `destination` already exists, `makeFolderWriteableToUserOnLinux` before the first `cp` (covers a leftover tree from a prior failed run).
   - `makeFolderWriteableToUserOnLinux(destination)` between the two `cp`s (covers first launch / nested `doc-dev` mkdir). Same placement as #2680.

2. **`smart-macro-doc.service.ts`**
   - Catch documentation setup failures inside `start()` and continue. Bundled smart-macro docs are not required for keymap editing; a docs-only error must not abort `createWindow`.

## Repro (Agent 10.1.0, also 7.x)

```bash
# first-launch path
rm -rf ~/.config/uhk-agent
uhk-agent
# log: EACCES mkdir '.../firmware/v<VER>/doc-dev'
#      UnhandledPromiseRejectionWarning
# process lives, no window

# subsequent-launch path
chmod -R a-w ~/.config/uhk-agent/smart-macro-docs/UltimateHackingKeyboard/firmware/v<VER>
uhk-agent
# log: EACCES unlink '.../bootstrap.min.css' (or similar)
```

Workaround today: `chmod -R u+w ~/.config/uhk-agent/smart-macro-docs` before each launch (and again after every new bundled doc version creates a fresh `0555` tree).

## Root cause note (for #2679 discussion)

Nothing "changed on the NixOS side" in the sense of a chmod regression. Node's `fs.cp` (used after the electron/node upgrade path) preserves source modes into the destination. The install prefix on Nix is always mode `0555` for directories; the first successful create of a new `v<VER>` directory stamps that mode onto the user's config tree. The `chmod -R +w` that already exists in-tree is simply sequenced after the copy that needs it.

## Related

- Fixes #2652
- Fixes #2679
- Supersedes #2680 (CLA was signed; this PR also covers the pre-first-cp case and the hard-fail-on-docs startup path)
- CLA: #3023

## Test plan

- [ ] Fresh `~/.config/uhk-agent` on a NixOS (or other immutable-prefix) install: Agent window appears; log shows `[SmartMacroCopy] done` and `[SmartMacroService] started on <port>`
- [ ] `chmod -R a-w` the `firmware/v*` tree, relaunch: same success, no EACCES
- [ ] Second relaunch after another `chmod -R a-w`: idempotent success
- [ ] Non-Nix install (normal FHS AppImage extract): no regression on first or second launch