### PR TITLE
fix: status buffer split and missing binding-site lines

### DIFF
--- a/packages/uhk-agent/src/services/device.service.ts
+++ b/packages/uhk-agent/src/services/device.service.ts
@@ -1237,6 +1237,9 @@ export class DeviceService {
                     const state = await this.device.getDeviceConnectionStateAsync();
                     if (!isEqual(state, this.savedState)) {
                         const newState = cloneDeep(state);
+                        const becameAvailable = state.hasPermission
+                            && state.communicationInterfaceAvailable
+                            && !(this.savedState?.hasPermission && this.savedState?.communicationInterfaceAvailable);
 
                         if (state.hasPermission && state.communicationInterfaceAvailable) {
                             state.hardwareModules = await this.getHardwareModules(false);
@@ -1279,7 +1282,12 @@ export class DeviceService {
                                 await this.dongleZephyrLogService.disable();
                             }
 
-                            this._checkStatusBuffer = true;
+                            // Only pull the status buffer when the device newly becomes available.
+                            // Re-reading on every connection-state field change drains leftovers from
+                            // a previous partial read (or an empty buffer) and overwrites the UI (#3025).
+                            if (becameAvailable) {
+                                this._checkStatusBuffer = true;
+                            }
                         } else {
                             deviceProtocolVersion = undefined;
                             state.hardwareModules = {

--- a/packages/uhk-usb/src/uhk-operations.ts
+++ b/packages/uhk-usb/src/uhk-operations.ts
@@ -812,27 +812,45 @@ export class UhkOperations {
         return convertSlaveI2cErrorBuffer(responseBuffer, slaveId);
     }
 
-    public async getVariable(variableId: UsbVariables, iteration: number = 0): Promise<number | string> {
-        this.logService.usbOps(`[DeviceOperation] USB[T]: get variable: ${UsbVariables[variableId]}. Iteration: ${iteration}`);
-        const buffer = Buffer.from([UsbCommand.GetVariable, variableId]);
-        const responseBuffer = await this.device.write(buffer);
-
+    public async getVariable(variableId: UsbVariables): Promise<number | string> {
         if (variableId === UsbVariables.statusBuffer || variableId === UsbVariables.ShellBuffer) {
-            let message = readUhkResponseAs0EndString(UhkBuffer.fromArray(convertBufferToIntArray(responseBuffer)));
-            this.logService.misc(`[DeviceOperation] status buffer segment: ${message}`);
-            if (message.length === responseBuffer.length - 1 && iteration < 20) {
-                message += await this.getVariable(variableId, iteration + 1);
+            // Firmware status buffer is STATUS_BUFFER_MAX_LENGTH (3000); shell buffer is 2048.
+            // Each USB transfer returns at most (report length - 1) payload bytes (~62).
+            // The previous hard cap of 20 iterations (~1260 bytes) left unread data in the device,
+            // which the next poll then showed alone and overwrote the UI (#3025).
+            const maxIterations = 100;
+            let message = '';
+
+            for (let iteration = 0; iteration < maxIterations; iteration++) {
+                this.logService.usbOps(`[DeviceOperation] USB[T]: get variable: ${UsbVariables[variableId]}. Iteration: ${iteration}`);
+                const buffer = Buffer.from([UsbCommand.GetVariable, variableId]);
+                const responseBuffer = await this.device.write(buffer);
+                const segment = readUhkResponseAs0EndString(UhkBuffer.fromArray(convertBufferToIntArray(responseBuffer)));
+                this.logService.misc(`[DeviceOperation] status buffer segment: ${segment}`);
+                message += segment;
+
+                if (segment.length !== responseBuffer.length - 1) {
+                    break;
+                }
+
+                if (iteration === maxIterations - 1) {
+                    this.logService.error(`[DeviceOperation] ${UsbVariables[variableId]} truncated after ${maxIterations} USB transfers`);
+                }
             }
 
             // The shell buffer carries a raw VT100 stream (colors, cursor control) that must be
             // forwarded verbatim to the terminal emulator. Only the macro status buffer gets the
             // dedup/reorder normalization.
-            if (iteration === 0 && variableId === UsbVariables.statusBuffer) {
+            if (variableId === UsbVariables.statusBuffer) {
                 message = normalizeStatusBuffer(message);
             }
 
             return message;
         }
+
+        this.logService.usbOps(`[DeviceOperation] USB[T]: get variable: ${UsbVariables[variableId]}`);
+        const buffer = Buffer.from([UsbCommand.GetVariable, variableId]);
+        const responseBuffer = await this.device.write(buffer);
 
         return responseBuffer[1];
     }

--- a/packages/uhk-web/src/app/util/status-buffer-parser.ts
+++ b/packages/uhk-web/src/app/util/status-buffer-parser.ts
@@ -68,6 +68,11 @@ function transformToErrorBlock(macros: Macro[], block: string): string {
 
     const url = `#/macro/${macro.id}?actionIndex=${macroActionIndex}&lineNr=${lineNr}&columnNr=${columnNr}&inlineEdit=true`;
     const newLine2 = `${escapeHtml(line1Result[1])}<a href="${url}">${escapeHtml(line1Result[2])}</a>`;
+    // Keep binding-site lines and nested location-stack lines (firmware may emit more than 3).
+    const extraLines = lines
+        .slice(3)
+        .map(line => escapeHtml(line))
+        .join('\n');
 
-    return `${escapeHtml(lines[0])}\n${newLine2}\n${escapeHtml(lines[2])}\n`;
+    return `${escapeHtml(lines[0])}\n${newLine2}\n${escapeHtml(lines[2])}\n${extraLines}`;
 }


### PR DESCRIPTION
## Summary
- Drain the full status/shell buffer (up to 100 USB transfers) instead of stopping after ~1260 bytes, which left leftovers that later overwrote the UI
- Only re-fetch the status buffer when the device newly becomes available (or when dirty), not on every connection-state field change
- Preserve binding-site / nested location-stack lines in the status buffer error panel

Fixes #3025

## Test plan
- [ ] Run `diagnose usb` on UHK 60 with a long status buffer and confirm Agent shows the full message (not a short leftover fragment)
- [ ] Trigger a macro validation error that includes a binding-site line and confirm that line stays visible in the error panel
- [ ] Reconnect the keyboard and confirm the status buffer is still shown after subsequent connection-state updates (e.g. zephyr log flag changes)

Made with [Cursor](https://cursor.com)